### PR TITLE
Leehk feat: get executives, sig/pig global status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ sqlite3 ./YOUR_DB_FILENAME.db "select * from user;"
 API_SECRET="some-secret-code"
 SESSION_SECRET="some-session-secret"
 SQLITE_FILENAME="YOUR_DB_FILENAME.db"
+IMAGE_DIR="/static/image/photo"
+IMAGE_MAX_SIZE=10000000
 ```
 
 | Key Name           | Description                                                      |
 |--------------------|------------------------------------------------------------------|
 | `API_SECRET`       | API 요청 시 검증에 사용되는 비밀 코드. 일치하지 않으면 401 반환  |
 | `SESSION_SECRET`   | 로그인 세션을 암호화하거나 검증하는 데 사용하는 비밀 키          |
-| `SQLITE_FILENAME` | SQLite3 데이터베이스 파일의 경로 또는 파일 이름                  |
+| `SQLITE_FILENAME`  | SQLite3 데이터베이스 파일의 경로 또는 파일 이름                  |
+| `IMAGE_DIR`        | 이미지 업로드 경로 |
+| `IMAGE_MAX_SIZE`   | 이미지 최대 용량(바이트) |
 
 실행합니다. `fastapi-cli`를 요구합니다.
 ```bash

--- a/docs/common.md
+++ b/docs/common.md
@@ -10,3 +10,11 @@ x-api-secret: YOUR_SECRET_KEY
 
 - **Status Codes**:
   - `401 Unauthorized` (인증 실패 시)
+
+# SQL 관련
+
+## 외래키 사용 설정
+
+```sql
+PRAGMA foreign_keys = ON;
+```

--- a/docs/image.md
+++ b/docs/image.md
@@ -1,0 +1,98 @@
+# 이미지 업로드 관련 DB, API 명세서
+**최신개정일:** 2025-05-21
+
+# DB 구조
+
+## 이미지 메타데이터 DB
+```sql
+CREATE TABLE image (
+    id TEXT PRIMARY KEY,
+    original_filename TEXT NOT NULL,
+    size INT NOT NULL,
+    mime_type TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    owner TEXT,
+    FOREIGN KEY (owner) REFERENCES user(id) ON DELETE SET NULL
+);
+```
+- id는 uuid v4를 사용한다
+- owner가 user 테이블에서 삭제되면 owner를 NULL로 바꾼다
+- 파일 최대 크기와 파일 저장 경로는 `.env`를 통해 설정된다.
+
+### 논의점
+- 파일 최대 크기를 얼마로 할지 정해야 함
+
+
+## SQL 관련
+```sql
+CREATE INDEX idx_image_owner ON image(owner);
+```
+
+---
+
+## 🔹 Upload Image (이미지 업로드)
+
+* **Method**: `POST`
+* **URL**: `/api/image/upload`
+* **설명**: 인증된 사용자가 이미지를 업로드한다. 업로드된 이미지 정보는 DB에 저장되며, 고유한 `id(UUID v4)`가 부여된다.
+
+* **Request**:
+  * **Content-Type**: `multipart/form-data`
+  * **Form Fields**:
+
+    | 필드명  | 타입   | 필수 여부 | 설명                    |
+    | ---- | ---- | ----- | --------------------- |
+    | file | File | ✅     | 업로드할 이미지 (PNG, JPG 등) |
+
+* **Response**:
+
+```json
+{
+  "id": "4c85a8be-59c3-4e1a-bd2f-9f22a0f4d22e",
+  "original_filename": "profile.jpg",
+  "size": 204832,
+  "mime_type": "image/jpeg",
+  "created_at": "2025-05-21T14:30:00",
+  "owner": "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514",
+}
+```
+
+* **Status Codes**:
+  * `201 Created` - 업로드 성공
+  * `400 Bad Request` - 파일 누락 또는 유효하지 않은 이미지
+  * `401 Unauthorized` - 인증 실패
+  * `413 Payload Too Large` - 파일 크기 제한 초과
+
+---
+
+## 🔹 Download Image (이미지 다운로드)
+
+* **Method**: `GET`
+* **URL**: `/api/image/download/:id`
+* **설명**: 업로드된 이미지를 ID(UUID)로 다운로드한다.
+
+* **Path Parameters**:
+
+  | 파라미터명 | 타입   | 설명               |
+  | ----- | ---- | ---------------- |
+  | `id`  | TEXT | 이미지 UUID (v4 형식) |
+
+* **Response**:
+  * **Content-Type**: 이미지의 `mime_type` (예: `image/png`, `image/jpeg`)
+  * 이미지 바이너리 스트림
+
+* **예시 요청**:
+
+```http
+GET /api/image/download/4c85a8be-59c3-4e1a-bd2f-9f22a0f4d22e
+```
+
+
+* **Status Codes**:
+
+  * `200 OK` - 다운로드 성공
+  * `401 Unauthorized` - 인증 실패
+  * `404 Not Found` - 존재하지 않는 이미지 ID
+
+---
+

--- a/docs/user.md
+++ b/docs/user.md
@@ -59,11 +59,6 @@ CREATE TABLE major (
 ```
 
 ## SQL 관련
-외래키 사용 설정
-```sql
-PRAGMA foreign_keys = ON;
-```
-
 ```sql
 CREATE INDEX idx_user_major ON user(major_id);
 ```

--- a/docs/user.md
+++ b/docs/user.md
@@ -102,8 +102,8 @@ END;
 {
   "email": "user@example.com",
   "name": "홍길동",
-  "phone": "010-1234-5678",
-  "student_id": "2023-12345",
+  "phone": "01012345678",
+  "student_id": "202312345",
   "major_id": 1
 }
 ```
@@ -113,8 +113,8 @@ END;
   "id": "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514",
   "email": "user@example.com",
   "name": "홍길동",
-  "phone": "010-1234-5678",
-  "student_id": "2023-12345",
+  "phone": "01012345678",
+  "student_id": "202312345",
   "role": "user",
   "status": "pending",
   "major_id": 1,
@@ -142,8 +142,8 @@ END;
   "id": "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514",
   "email": "user@example.com",
   "name": "홍길동",
-  "phone": "010-1234-5678",
-  "student_id": "2023-12345",
+  "phone": "01012345678",
+  "student_id": "202312345",
   "role": "user",
   "status": "active",
   "major_id": 1,
@@ -158,6 +158,72 @@ END;
 
 ---
 
+수정된 **API 문서**는 아래와 같습니다. 주어진 SQL 정의에 따라 사용자 데이터 형식 (`id`, `phone`, `student_id`, 등)을 반영하여 명확하게 정리했습니다.
+
+---
+
+## 🔹 Get Executives (임원 목록 조회)
+
+- **Method**: `GET`
+- **URL**: `/api/user/executives`
+- **설명**: 현재 등록된 임원(`executive`) 사용자들의 목록을 조회합니다.
+- **Response**:
+
+```json
+[
+  {
+    "id": "f81d4fae7dec11d0a76500a0c91e6bf6",
+    "email": "executive@example.com",
+    "name": "홍길동",
+    "phone": "01012345678",
+    "student_id": "202512345",
+    "role": "executive",
+    "status": "active",
+    "major_id": 1,
+    "last_login": "2025-05-01T09:00:00",
+    "created_at": "2025-04-01T12:00:00",
+    "updated_at": "2025-04-30T12:00:00"
+  }
+]
+```
+
+- **Status Codes**:
+  - `200 OK`
+  - `401 Unauthorized`
+
+---
+
+## 🔹 Get Presidents (회장 목록 조회)
+
+* **Method**: `GET`
+* **URL**: `/api/user/presidents`
+* **설명**: 현재 등록된 회장(`president`) 사용자들의 목록을 조회합니다.
+* **Response**:
+
+```json
+[
+  {
+    "id": "a1b2c3d4e5f67890abcd1234567890ef",
+    "email": "president@example.com",
+    "name": "이순신",
+    "phone": "01098765432",
+    "student_id": "202412345",
+    "role": "president",
+    "status": "active",
+    "major_id": 2,
+    "last_login": "2025-05-10T08:30:00",
+    "created_at": "2024-03-01T00:00:00",
+    "updated_at": "2025-02-28T23:59:59"
+  }
+]
+```
+
+- **Status Codes**:
+  - `200 OK`
+  - `401 Unauthorized`
+
+---
+
 ## 🔹 Update My Profile (내 정보 수정)
 
 - **Method**: `POST`  
@@ -167,8 +233,8 @@ END;
 ```json
 {
   "name": "김철수",
-  "phone": "010-5678-1234", 
-  "student_id": "2023-12345", 
+  "phone": "01056781234", 
+  "student_id": "202312345", 
   "major_id": 2
 }
 ```

--- a/script/init_db.sh
+++ b/script/init_db.sh
@@ -76,7 +76,7 @@ CREATE TABLE sig (
     title TEXT NOT NULL,
     description TEXT NOT NULL,
     content_src TEXT NOT NULL UNIQUE,
-    status TEXT DEFAULT 'surveying' NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
     year INTEGER NOT NULL CHECK (year >= 2025),
     semester INTEGER NOT NULL CHECK (semester IN (1, 2)),
 
@@ -92,7 +92,7 @@ CREATE TABLE pig (
     title TEXT NOT NULL,
     description TEXT NOT NULL,
     content_src TEXT NOT NULL UNIQUE,
-    status TEXT DEFAULT 'surveying' NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
     year INTEGER NOT NULL CHECK (year >= 2025),
     semester INTEGER NOT NULL CHECK (semester IN (1, 2)),
 
@@ -109,9 +109,10 @@ CREATE TABLE sig_member (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     ig_id INTEGER NOT NULL,
     user_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    UNIQUE (ig_id, user_id),
+    UNIQUE (ig_id, user_id, status),
     FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
     FOREIGN KEY (ig_id) REFERENCES sig(id) ON DELETE CASCADE
 );
@@ -119,9 +120,10 @@ CREATE TABLE pig_member (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     ig_id INTEGER NOT NULL,
     user_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    UNIQUE (ig_id, user_id),
+    UNIQUE (ig_id, user_id, status),
     FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
     FOREIGN KEY (ig_id) REFERENCES pig(id) ON DELETE CASCADE
 );
@@ -168,6 +170,43 @@ BEGIN
     SET updated_at = CURRENT_TIMESTAMP
     WHERE id = OLD.id;
 END;
+
+-- SIG/PIG global status
+CREATE TABLE sig_global_status (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE pig_global_status (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    status TEXT NOT NULL CHECK (status IN ('surveying', 'recruiting', 'active', 'inactive')),
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_sig_global_status_updated_at
+AFTER UPDATE ON sig_global_status
+FOR EACH ROW
+WHEN 
+    OLD.status != NEW.status
+BEGIN
+    UPDATE sig_global_status
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE id = OLD.id;
+END;
+
+CREATE TRIGGER update_pig_global_status_updated_at
+AFTER UPDATE ON pig_global_status
+FOR EACH ROW
+WHEN 
+    OLD.status != NEW.status
+BEGIN
+    UPDATE pig_global_status
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE id = OLD.id;
+END;
+
+INSERT INTO sig_global_status (id, status) VALUES (1, 'inactive');
+INSERT INTO pig_global_status (id, status) VALUES (1, 'inactive');
 
 EOF
 

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -6,11 +6,9 @@ from src.model import User
 
 def get_current_user(request: Request, session: SessionDep) -> User:
     user_id = request.session.get("user_id")
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not logged in")
+    if not user_id: raise HTTPException(401, detail="Not logged in")
 
     user = session.get(User, user_id)
-    if not user:
-        raise HTTPException(status_code=401, detail="User not found")
+    if not user: raise HTTPException(401, detail="User not found")
 
     return user

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -4,3 +4,5 @@ from .pig_member import PIGMember
 from .sig import SIG, SIGStatus
 from .sig_member import SIGMember
 from .user import User, UserRole, UserStatus
+from .sig_global_status import SIGGlobalStatus
+from .pig_global_status import PIGGlobalStatus

--- a/src/model/pig.py
+++ b/src/model/pig.py
@@ -27,16 +27,12 @@ class PIG(SQLModel, table=True):
     description: str = Field(nullable=False)
     content_src: str = Field(nullable=False, unique=True)
 
-    status: PIGStatus = Field(default=PIGStatus.surveying, nullable=False)
+    status: PIGStatus = Field(nullable=False)
 
     year: int = Field(nullable=False)
     semester: int = Field(nullable=False)
 
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
-    updated_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
 
     owner: str = Field(foreign_key="user.id", nullable=False)

--- a/src/model/pig_global_status.py
+++ b/src/model/pig_global_status.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from sqlmodel import CheckConstraint, Field, SQLModel
+
+from .pig import PIGStatus
+
+
+class PIGGlobalStatus(SQLModel, table=True):
+    __tablename__ = "pig_global_status"  # type: ignore
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_id_valid"),
+    )
+
+    id: int = Field(default=None, primary_key=True)
+    status: PIGStatus = Field(default=None, nullable=False)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/model/pig_member.py
+++ b/src/model/pig_member.py
@@ -3,18 +3,19 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel, UniqueConstraint
 
+from .pig import PIGStatus
+
 
 class PIGMember(SQLModel, table=True):
     __tablename__ = "pig_member"  # type: ignore
     __table_args__ = (
-        UniqueConstraint("ig_id", "user_id", name="uq_ig_user"),
+        UniqueConstraint("ig_id", "user_id", "status", name="uq_ig_user_status"),
     )
 
     id: Optional[int] = Field(default=None, primary_key=True)
 
     ig_id: int = Field(foreign_key="pig.id", nullable=False)
     user_id: str = Field(foreign_key="user.id", nullable=False)
+    status: PIGStatus = Field(nullable=False)
 
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/model/sig.py
+++ b/src/model/sig.py
@@ -15,8 +15,7 @@ class SIGStatus(str, Enum):
 class SIG(SQLModel, table=True):
     __tablename__ = "sig"  # type: ignore
     __table_args__ = (
-        UniqueConstraint("title", "year", "semester",
-                         name="uq_title_year_semester"),
+        UniqueConstraint("title", "year", "semester", name="uq_title_year_semester"),
         CheckConstraint("year >= 2025", name="ck_year_min"),
         CheckConstraint("semester IN (1, 2)", name="ck_semester_valid"),
     )
@@ -27,16 +26,12 @@ class SIG(SQLModel, table=True):
     description: str = Field(nullable=False)
     content_src: str = Field(nullable=False, unique=True)
 
-    status: SIGStatus = Field(default=SIGStatus.surveying, nullable=False)
+    status: SIGStatus = Field(nullable=False)
 
     year: int = Field(nullable=False)
     semester: int = Field(nullable=False)
 
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
-    updated_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
 
     owner: str = Field(foreign_key="user.id", nullable=False)

--- a/src/model/sig_global_status.py
+++ b/src/model/sig_global_status.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from sqlmodel import CheckConstraint, Field, SQLModel
+
+from .sig import SIGStatus
+
+
+class SIGGlobalStatus(SQLModel, table=True):
+    __tablename__ = "sig_global_status"  # type: ignore
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_id_valid"),
+    )
+
+    id: int = Field(default=None, primary_key=True)
+    status: SIGStatus = Field(default=None, nullable=False)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/model/sig_member.py
+++ b/src/model/sig_member.py
@@ -3,18 +3,19 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel, UniqueConstraint
 
+from .sig import SIGStatus
+
 
 class SIGMember(SQLModel, table=True):
     __tablename__ = "sig_member"  # type: ignore
     __table_args__ = (
-        UniqueConstraint("ig_id", "user_id", name="uq_ig_user"),
+        UniqueConstraint("ig_id", "user_id", "status", name="uq_ig_user_status"),
     )
 
     id: Optional[int] = Field(default=None, primary_key=True)
 
     ig_id: int = Field(foreign_key="sig.id", nullable=False)
     user_id: str = Field(foreign_key="user.id", nullable=False)
+    status: SIGStatus = Field(nullable=False)
 
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=False
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/routes/major.py
+++ b/src/routes/major.py
@@ -20,11 +20,10 @@ class BodyCreateMajor(BaseModel):
 async def create_major(body: BodyCreateMajor, session: SessionDep) -> Major:
     major = Major(college=body.college, major_name=body.major_name)
     session.add(major)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="major already exists")
+        raise HTTPException(409, detail="major already exists")
     session.refresh(major)
     return major
 
@@ -37,35 +36,30 @@ async def get_all_majors(session: SessionDep) -> Sequence[Major]:
 @major_router.get('/major/{id}')
 async def get_major_by_id(id: int, session: SessionDep) -> Major:
     major = session.get(Major, id)
-    if not major:
-        raise HTTPException(status_code=404, detail="major not found")
+    if not major: raise HTTPException(404, detail="major not found")
     return major
 
 
 @major_router.post('/executive/major/update/{id}', status_code=204)
 async def update_major(id: int, body: BodyCreateMajor, session: SessionDep) -> None:
     major = session.get(Major, id)
-    if not major:
-        raise HTTPException(status_code=404, detail="major not found")
+    if not major: raise HTTPException(404, detail="major not found")
     major.college = body.college
     major.major_name = body.major_name
     session.add(major)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="major already exists")
+        raise HTTPException(409, detail="major already exists")
     return
 
 
 @major_router.post('/executive/major/delete/{id}', status_code=204)
 async def delete_major(id: int, session: SessionDep) -> None:
     major = session.get(Major, id)
-    if not major:
-        raise HTTPException(status_code=404, detail="major not found")
+    if not major: raise HTTPException(404, detail="major not found")
     session.delete(major)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
         raise HTTPException(

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -24,12 +24,9 @@ class BodyCreatePIG(BaseModel):
 
 @pig_router.post('/pig/create', status_code=201)
 async def create_pig(body: BodyCreatePIG, session: SessionDep, current_user: User = Depends(get_current_user), pig_global_status: PIGGlobalStatus = Depends(get_pig_global_status)) -> PIG:
-    if pig_global_status.status != PIGStatus.surveying:
-        raise HTTPException(400, "cannot create pig when pig global status is not surveying")
-    if not is_valid_year(body.year):
-        raise HTTPException(422, detail="invalid year")
-    if not is_valid_semester(body.semester):
-        raise HTTPException(422, detail="invalid semester")
+    if pig_global_status.status != PIGStatus.surveying: raise HTTPException(400, "cannot create pig when pig global status is not surveying")
+    if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
+    if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
 
     pig = PIG(
         title=body.title,
@@ -41,14 +38,12 @@ async def create_pig(body: BodyCreatePIG, session: SessionDep, current_user: Use
         status=PIGStatus.surveying
     )
     session.add(pig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     session.refresh(pig)
-    if pig.id is None:
-        raise HTTPException(status_code=503, detail="pig primary key does not exist")
+    if pig.id is None: raise HTTPException(503, detail="pig primary key does not exist")
     pig_member = PIGMember(
         ig_id=pig.id,
         user_id=current_user.id,
@@ -63,8 +58,7 @@ async def create_pig(body: BodyCreatePIG, session: SessionDep, current_user: Use
 @pig_router.get('/pig/{id}')
 async def get_pig_by_id(id: int, session: SessionDep) -> PIG:
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="pig not found")
     return pig
 
 
@@ -84,15 +78,11 @@ class BodyUpdateMyPIG(BaseModel):
 @pig_router.post('/pig/{id}/update', status_code=204)
 async def update_my_pig(id: int, body: BodyUpdateMyPIG, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
-    if pig.owner != current_user.id:
-        raise HTTPException(
-            status_code=403, detail="cannot update pig of other")
-    if not is_valid_year(body.year):
-        raise HTTPException(422, detail="invalid year")
-    if not is_valid_semester(body.semester):
-        raise HTTPException(422, detail="invalid semester")
+    if not pig: raise HTTPException(404, detail="pig not found")
+    if pig.owner != current_user.id: raise HTTPException(
+        status_code=403, detail="cannot update pig of other")
+    if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
+    if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
 
     pig.title = body.title
     pig.description = body.description
@@ -100,21 +90,18 @@ async def update_my_pig(id: int, body: BodyUpdateMyPIG, session: SessionDep, cur
     pig.year = body.year
     pig.semester = body.semester
     session.add(pig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @pig_router.post('/pig/{id}/delete', status_code=204)
 async def delete_my_pig(id: int, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
-    if pig.owner != current_user.id:
-        raise HTTPException(status_code=403, detail="cannot delete pig of other")
+    if not pig: raise HTTPException(404, detail="pig not found")
+    if pig.owner != current_user.id: raise HTTPException(403, detail="cannot delete pig of other")
     session.delete(pig)
     session.commit()
     return
@@ -132,8 +119,7 @@ class BodyUpdatePIG(BaseModel):
 @pig_router.post('/executive/pig/{id}/update', status_code=204)
 async def update_pig(id: int, body: BodyUpdatePIG, session: SessionDep) -> None:
     pig = session.get(PIG, id)
-    if pig is None:
-        raise HTTPException(404, detail="no pig exists")
+    if pig is None: raise HTTPException(404, detail="no pig exists")
     if body.title:
         pig.title = body.title
     if body.description:
@@ -143,27 +129,23 @@ async def update_pig(id: int, body: BodyUpdatePIG, session: SessionDep) -> None:
     if body.status:
         pig.status = body.status
     if body.year:
-        if not is_valid_year(body.year):
-            raise HTTPException(422, detail="invalid year")
+        if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
         pig.year = body.year
     if body.semester:
-        if not is_valid_semester(body.semester):
-            raise HTTPException(422, detail="invalid semester")
+        if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
         pig.semester = body.semester
     session.add(pig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @pig_router.post('/executive/pig/{id}/delete', status_code=204)
 async def delete_pig(id: int, session: SessionDep) -> None:
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="pig not found")
     session.delete(pig)
     session.commit()
     return
@@ -176,15 +158,12 @@ class BodyHandoverPIG(BaseModel):
 @pig_router.post('/pig/{id}/handover', status_code=204)
 async def handover_pig(id: int, body: BodyHandoverPIG, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     pig = session.get(PIG, id)
-    if pig is None:
-        raise HTTPException(404, detail="no pig exists")
+    if pig is None: raise HTTPException(404, detail="no pig exists")
     user = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(
         PIGMember.user_id == body.new_owner)).first()
-    if not user:
-        raise HTTPException(
-            status_code=404, detail="new_owner should be a member of the pig")
-    if current_user.role < UserRole.executive and current_user.id != pig.owner:
-        raise HTTPException(403, "handover can be executed only by executive or owner of the pig")
+    if not user: raise HTTPException(
+        status_code=404, detail="new_owner should be a member of the pig")
+    if current_user.role < UserRole.executive and current_user.id != pig.owner: raise HTTPException(403, "handover can be executed only by executive or owner of the pig")
     pig.owner = body.new_owner
     session.add(pig)
     session.commit()
@@ -199,34 +178,28 @@ async def get_pig_members(id: int, session: SessionDep) -> Sequence[PIGMember]:
 @pig_router.post('/pig/{id}/member/join', status_code=204)
 async def join_pig(id: int, session: SessionDep, current_user: User = Depends(get_current_user)):
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
-    if pig.status not in (PIGStatus.surveying, PIGStatus.recruiting):
-        raise HTTPException(400, "cannot join to pig when pig status is not surveying/recruiting")
+    if not pig: raise HTTPException(404, detail="pig not found")
+    if pig.status not in (PIGStatus.surveying, PIGStatus.recruiting): raise HTTPException(400, "cannot join to pig when pig status is not surveying/recruiting")
     pig_member = PIGMember(
         ig_id=id,
         user_id=current_user.id,
         status=pig.status
     )
     session.add(pig_member)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @pig_router.post('/pig/{id}/member/leave', status_code=204)
 async def leave_pig(id: int, session: SessionDep, current_user: User = Depends(get_current_user), pig_global_status: PIGGlobalStatus = Depends(get_pig_global_status)):
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
-    if pig.owner == current_user.id:
-        raise HTTPException(status_code=409, detail="pig owner cannot leave the pig")
+    if not pig: raise HTTPException(404, detail="pig not found")
+    if pig.owner == current_user.id: raise HTTPException(409, detail="pig owner cannot leave the pig")
     pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id).where(PIGMember.status == pig_global_status.status)).first()
-    if not pig_member:
-        raise HTTPException(status_code=404, detail="pig member not found")
+    if not pig_member: raise HTTPException(404, detail="pig member not found")
     session.delete(pig_member)
     session.commit()
     return
@@ -239,22 +212,19 @@ class BodyExecutiveJoinPIG(BaseModel):
 @pig_router.post('/executive/pig/{id}/member/join', status_code=204)
 async def executive_join_pig(id: int, body: BodyExecutiveJoinPIG, session: SessionDep):
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="pig not found")
     user = session.get(User, body.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="user not found")
+    if not user: raise HTTPException(404, detail="user not found")
     pig_member = PIGMember(
         ig_id=id,
         user_id=body.user_id,
         status=pig.status
     )
     session.add(pig_member)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
@@ -265,16 +235,12 @@ class BodyExecutiveLeavePIG(BaseModel):
 @pig_router.post('/executive/pig/{id}/member/leave', status_code=204)
 async def executive_leave_pig(id: int, body: BodyExecutiveLeavePIG, session: SessionDep):
     pig = session.get(PIG, id)
-    if not pig:
-        raise HTTPException(status_code=404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="pig not found")
     user = session.get(User, body.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="user not found")
-    if pig.owner == user.id:
-        raise HTTPException(status_code=409, detail="pig owner cannot leave the pig")
+    if not user: raise HTTPException(404, detail="user not found")
+    if pig.owner == user.id: raise HTTPException(409, detail="pig owner cannot leave the pig")
     pig_members = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == body.user_id)).all()
-    if not pig_members:
-        raise HTTPException(status_code=404, detail="pig member not found")
+    if not pig_members: raise HTTPException(404, detail="pig member not found")
     for member in pig_members:
         session.delete(member)
     session.commit()
@@ -302,15 +268,13 @@ _valid_pig_global_status_update = (
 
 def _check_valid_pig_global_status_update(old_status: PIGStatus, new_status: PIGStatus) -> bool:
     for valid_update in _valid_pig_global_status_update:
-        if (old_status, new_status) == valid_update:
-            return True
+        if (old_status, new_status) == valid_update: return True
     return False
 
 
 @pig_router.post('/executive/pig/global/status', status_code=204)
 async def update_pig_global_status(body: BodyUpdatePIGGlobalStatus, session: SessionDep, pig_global_status: PIGGlobalStatus = Depends(get_pig_global_status)):
-    if not _check_valid_pig_global_status_update(pig_global_status.status, body.status):
-        raise HTTPException(400, "invalid pig global status update")
+    if not _check_valid_pig_global_status_update(pig_global_status.status, body.status): raise HTTPException(400, "invalid pig global status update")
     if body.status == PIGStatus.inactive:
         pigs = session.exec(select(PIG).where(PIG.status != PIGStatus.inactive)).all()
         for pig in pigs:

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -7,8 +7,9 @@ from sqlmodel import select
 
 from src.auth import get_current_user
 from src.db import SessionDep
-from src.model import SIG, SIGMember, SIGStatus, User, UserRole
+from src.model import SIG, SIGGlobalStatus, SIGMember, SIGStatus, User, UserRole
 from src.util import is_valid_semester, is_valid_year
+from src.util import get_sig_global_status
 
 sig_router = APIRouter(tags=['sig'])
 
@@ -22,7 +23,9 @@ class BodyCreateSIG(BaseModel):
 
 
 @sig_router.post('/sig/create', status_code=201)
-async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: User = Depends(get_current_user)) -> SIG:
+async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: User = Depends(get_current_user), sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)) -> SIG:
+    if sig_global_status.status != SIGStatus.surveying:
+        raise HTTPException(400, "cannot create sig when sig global status is not surveying")
     if not is_valid_year(body.year):
         raise HTTPException(422, detail="invalid year")
     if not is_valid_semester(body.semester):
@@ -34,22 +37,22 @@ async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: Use
         content_src=body.content_src,
         year=body.year,
         semester=body.semester,
-        owner=current_user.id
+        owner=current_user.id,
+        status=SIGStatus.surveying
     )
     session.add(sig)
     try:
         session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail=f"unique field already exists")
+        raise HTTPException(status_code=409, detail="unique field already exists")
     session.refresh(sig)
     if sig.id is None:
-        raise HTTPException(
-            status_code=503, detail=f"sig primary key does not exist")
+        raise HTTPException(status_code=503, detail="sig primary key does not exist")
     sig_member = SIGMember(
         ig_id=sig.id,
-        user_id=current_user.id
+        user_id=current_user.id,
+        status=sig.status
     )
     session.add(sig_member)
     session.commit()
@@ -101,8 +104,7 @@ async def update_my_sig(id: int, body: BodyUpdateMySIG, session: SessionDep, cur
         session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail=f"unique field already exists")
+        raise HTTPException(status_code=409, detail="unique field already exists")
     return
 
 
@@ -112,8 +114,7 @@ async def delete_my_sig(id: int, session: SessionDep, current_user: User = Depen
     if not sig:
         raise HTTPException(status_code=404, detail="sig not found")
     if sig.owner != current_user.id:
-        raise HTTPException(
-            status_code=403, detail="cannot delete sig of other")
+        raise HTTPException(status_code=403, detail="cannot delete sig of other")
     session.delete(sig)
     session.commit()
     return
@@ -154,8 +155,7 @@ async def update_sig(id: int, body: BodyUpdateSIG, session: SessionDep) -> None:
         session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail=f"unique field already exists")
+        raise HTTPException(status_code=409, detail="unique field already exists")
     return
 
 
@@ -184,8 +184,7 @@ async def handover_sig(id: int, body: BodyHandoverSIG, session: SessionDep, curr
         raise HTTPException(
             status_code=404, detail="new_owner should be a member of the sig")
     if current_user.role < UserRole.executive and current_user.id != sig.owner:
-        raise HTTPException(
-            403, "handover can be executed only by executive or owner of the sig")
+        raise HTTPException(403, "handover can be executed only by executive or owner of the sig")
     sig.owner = body.new_owner
     session.add(sig)
     session.commit()
@@ -202,30 +201,30 @@ async def join_sig(id: int, session: SessionDep, current_user: User = Depends(ge
     sig = session.get(SIG, id)
     if not sig:
         raise HTTPException(status_code=404, detail="sig not found")
+    if sig.status not in (SIGStatus.surveying, SIGStatus.recruiting):
+        raise HTTPException(400, "cannot join to sig when sig status is not surveying/recruiting")
     sig_member = SIGMember(
         ig_id=id,
-        user_id=current_user.id
+        user_id=current_user.id,
+        status=sig.status
     )
     session.add(sig_member)
     try:
         session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail=f"unique field already exists")
+        raise HTTPException(status_code=409, detail="unique field already exists")
     return
 
 
 @sig_router.post('/sig/{id}/member/leave', status_code=204)
-async def leave_sig(id: int, session: SessionDep, current_user: User = Depends(get_current_user)):
+async def leave_sig(id: int, session: SessionDep, current_user: User = Depends(get_current_user), sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)):
     sig = session.get(SIG, id)
     if not sig:
         raise HTTPException(status_code=404, detail="sig not found")
     if sig.owner == current_user.id:
-        raise HTTPException(
-            status_code=409, detail="sig owner cannot leave the sig")
-    sig_member = session.exec(select(SIGMember).where(
-        SIGMember.ig_id == id).where(SIGMember.user_id == current_user.id)).first()
+        raise HTTPException(status_code=409, detail="sig owner cannot leave the sig")
+    sig_member = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == current_user.id).where(SIGMember.status == sig_global_status.status)).first()
     if not sig_member:
         raise HTTPException(status_code=404, detail="sig member not found")
     session.delete(sig_member)
@@ -247,15 +246,15 @@ async def executive_join_sig(id: int, body: BodyExecutiveJoinSIG, session: Sessi
         raise HTTPException(status_code=404, detail="user not found")
     sig_member = SIGMember(
         ig_id=id,
-        user_id=body.user_id
+        user_id=body.user_id,
+        status=sig.status
     )
     session.add(sig_member)
     try:
         session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(
-            status_code=409, detail=f"unique field already exists")
+        raise HTTPException(status_code=409, detail="unique field already exists")
     return
 
 
@@ -272,12 +271,57 @@ async def executive_leave_sig(id: int, body: BodyExecutiveLeaveSIG, session: Ses
     if not user:
         raise HTTPException(status_code=404, detail="user not found")
     if sig.owner == user.id:
-        raise HTTPException(
-            status_code=409, detail="sig owner cannot leave the sig")
-    sig_member = session.exec(select(SIGMember).where(
-        SIGMember.ig_id == id).where(SIGMember.user_id == body.user_id)).first()
-    if not sig_member:
+        raise HTTPException(status_code=409, detail="sig owner cannot leave the sig")
+    sig_members = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == body.user_id)).all()
+    if not sig_members:
         raise HTTPException(status_code=404, detail="sig member not found")
-    session.delete(sig_member)
+    for member in sig_members:
+        session.delete(member)
+    session.commit()
+    return
+
+
+@sig_router.get('/sig/global/status')
+async def _get_sig_global_status(sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)):
+    return {'status': sig_global_status.status}
+
+
+class BodyUpdateSIGGlobalStatus(BaseModel):
+    status: SIGStatus
+
+
+_valid_sig_global_status_update = (
+    (SIGStatus.inactive, SIGStatus.surveying),
+    (SIGStatus.surveying, SIGStatus.recruiting),
+    (SIGStatus.recruiting, SIGStatus.active),
+    (SIGStatus.surveying, SIGStatus.inactive),
+    (SIGStatus.recruiting, SIGStatus.inactive),
+    (SIGStatus.active, SIGStatus.inactive),
+)
+
+
+def _check_valid_sig_global_status_update(old_status: SIGStatus, new_status: SIGStatus) -> bool:
+    for valid_update in _valid_sig_global_status_update:
+        if (old_status, new_status) == valid_update:
+            return True
+    return False
+
+
+@sig_router.post('/executive/sig/global/status', status_code=204)
+async def update_sig_global_status(body: BodyUpdateSIGGlobalStatus, session: SessionDep, sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)):
+    if not _check_valid_sig_global_status_update(sig_global_status.status, body.status):
+        raise HTTPException(400, "invalid sig global status update")
+    if body.status == SIGStatus.inactive:
+        sigs = session.exec(select(SIG).where(SIG.status != SIGStatus.inactive)).all()
+        for sig in sigs:
+            sig.status = SIGStatus.inactive
+            session.add(sig)
+    elif body.status in (SIGStatus.recruiting, SIGStatus.active):
+        sigs = session.exec(select(SIG).where(SIG.status == sig_global_status.status)).all()
+        for sig in sigs:
+            sig.status = body.status
+            session.add(sig)
+    sig_global_status.status = body.status
+    session.add(sig_global_status)
     session.commit()
     return

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -24,12 +24,9 @@ class BodyCreateSIG(BaseModel):
 
 @sig_router.post('/sig/create', status_code=201)
 async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: User = Depends(get_current_user), sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)) -> SIG:
-    if sig_global_status.status != SIGStatus.surveying:
-        raise HTTPException(400, "cannot create sig when sig global status is not surveying")
-    if not is_valid_year(body.year):
-        raise HTTPException(422, detail="invalid year")
-    if not is_valid_semester(body.semester):
-        raise HTTPException(422, detail="invalid semester")
+    if sig_global_status.status != SIGStatus.surveying: raise HTTPException(400, "cannot create sig when sig global status is not surveying")
+    if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
+    if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
 
     sig = SIG(
         title=body.title,
@@ -41,14 +38,12 @@ async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: Use
         status=SIGStatus.surveying
     )
     session.add(sig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     session.refresh(sig)
-    if sig.id is None:
-        raise HTTPException(status_code=503, detail="sig primary key does not exist")
+    if sig.id is None: raise HTTPException(503, detail="sig primary key does not exist")
     sig_member = SIGMember(
         ig_id=sig.id,
         user_id=current_user.id,
@@ -63,8 +58,7 @@ async def create_sig(body: BodyCreateSIG, session: SessionDep, current_user: Use
 @sig_router.get('/sig/{id}')
 async def get_sig_by_id(id: int, session: SessionDep) -> SIG:
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
+    if not sig: raise HTTPException(404, detail="sig not found")
     return sig
 
 
@@ -84,15 +78,11 @@ class BodyUpdateMySIG(BaseModel):
 @sig_router.post('/sig/{id}/update', status_code=204)
 async def update_my_sig(id: int, body: BodyUpdateMySIG, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
-    if sig.owner != current_user.id:
-        raise HTTPException(
-            status_code=403, detail="cannot update sig of other")
-    if not is_valid_year(body.year):
-        raise HTTPException(422, detail="invalid year")
-    if not is_valid_semester(body.semester):
-        raise HTTPException(422, detail="invalid semester")
+    if not sig: raise HTTPException(404, detail="sig not found")
+    if sig.owner != current_user.id: raise HTTPException(
+        status_code=403, detail="cannot update sig of other")
+    if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
+    if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
 
     sig.title = body.title
     sig.description = body.description
@@ -100,21 +90,18 @@ async def update_my_sig(id: int, body: BodyUpdateMySIG, session: SessionDep, cur
     sig.year = body.year
     sig.semester = body.semester
     session.add(sig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @sig_router.post('/sig/{id}/delete', status_code=204)
 async def delete_my_sig(id: int, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
-    if sig.owner != current_user.id:
-        raise HTTPException(status_code=403, detail="cannot delete sig of other")
+    if not sig: raise HTTPException(404, detail="sig not found")
+    if sig.owner != current_user.id: raise HTTPException(403, detail="cannot delete sig of other")
     session.delete(sig)
     session.commit()
     return
@@ -132,8 +119,7 @@ class BodyUpdateSIG(BaseModel):
 @sig_router.post('/executive/sig/{id}/update', status_code=204)
 async def update_sig(id: int, body: BodyUpdateSIG, session: SessionDep) -> None:
     sig = session.get(SIG, id)
-    if sig is None:
-        raise HTTPException(404, detail="no sig exists")
+    if sig is None: raise HTTPException(404, detail="no sig exists")
     if body.title:
         sig.title = body.title
     if body.description:
@@ -143,27 +129,23 @@ async def update_sig(id: int, body: BodyUpdateSIG, session: SessionDep) -> None:
     if body.status:
         sig.status = body.status
     if body.year:
-        if not is_valid_year(body.year):
-            raise HTTPException(422, detail="invalid year")
+        if not is_valid_year(body.year): raise HTTPException(422, detail="invalid year")
         sig.year = body.year
     if body.semester:
-        if not is_valid_semester(body.semester):
-            raise HTTPException(422, detail="invalid semester")
+        if not is_valid_semester(body.semester): raise HTTPException(422, detail="invalid semester")
         sig.semester = body.semester
     session.add(sig)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @sig_router.post('/executive/sig/{id}/delete', status_code=204)
 async def delete_sig(id: int, session: SessionDep) -> None:
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
+    if not sig: raise HTTPException(404, detail="sig not found")
     session.delete(sig)
     session.commit()
     return
@@ -176,15 +158,12 @@ class BodyHandoverSIG(BaseModel):
 @sig_router.post('/sig/{id}/handover', status_code=204)
 async def handover_sig(id: int, body: BodyHandoverSIG, session: SessionDep, current_user: User = Depends(get_current_user)) -> None:
     sig = session.get(SIG, id)
-    if sig is None:
-        raise HTTPException(404, detail="no sig exists")
+    if sig is None: raise HTTPException(404, detail="no sig exists")
     user = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(
         SIGMember.user_id == body.new_owner)).first()
-    if not user:
-        raise HTTPException(
-            status_code=404, detail="new_owner should be a member of the sig")
-    if current_user.role < UserRole.executive and current_user.id != sig.owner:
-        raise HTTPException(403, "handover can be executed only by executive or owner of the sig")
+    if not user: raise HTTPException(
+        status_code=404, detail="new_owner should be a member of the sig")
+    if current_user.role < UserRole.executive and current_user.id != sig.owner: raise HTTPException(403, "handover can be executed only by executive or owner of the sig")
     sig.owner = body.new_owner
     session.add(sig)
     session.commit()
@@ -199,34 +178,28 @@ async def get_sig_members(id: int, session: SessionDep) -> Sequence[SIGMember]:
 @sig_router.post('/sig/{id}/member/join', status_code=204)
 async def join_sig(id: int, session: SessionDep, current_user: User = Depends(get_current_user)):
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
-    if sig.status not in (SIGStatus.surveying, SIGStatus.recruiting):
-        raise HTTPException(400, "cannot join to sig when sig status is not surveying/recruiting")
+    if not sig: raise HTTPException(404, detail="sig not found")
+    if sig.status not in (SIGStatus.surveying, SIGStatus.recruiting): raise HTTPException(400, "cannot join to sig when sig status is not surveying/recruiting")
     sig_member = SIGMember(
         ig_id=id,
         user_id=current_user.id,
         status=sig.status
     )
     session.add(sig_member)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
 @sig_router.post('/sig/{id}/member/leave', status_code=204)
 async def leave_sig(id: int, session: SessionDep, current_user: User = Depends(get_current_user), sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)):
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
-    if sig.owner == current_user.id:
-        raise HTTPException(status_code=409, detail="sig owner cannot leave the sig")
+    if not sig: raise HTTPException(404, detail="sig not found")
+    if sig.owner == current_user.id: raise HTTPException(409, detail="sig owner cannot leave the sig")
     sig_member = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == current_user.id).where(SIGMember.status == sig_global_status.status)).first()
-    if not sig_member:
-        raise HTTPException(status_code=404, detail="sig member not found")
+    if not sig_member: raise HTTPException(404, detail="sig member not found")
     session.delete(sig_member)
     session.commit()
     return
@@ -239,22 +212,19 @@ class BodyExecutiveJoinSIG(BaseModel):
 @sig_router.post('/executive/sig/{id}/member/join', status_code=204)
 async def executive_join_sig(id: int, body: BodyExecutiveJoinSIG, session: SessionDep):
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
+    if not sig: raise HTTPException(404, detail="sig not found")
     user = session.get(User, body.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="user not found")
+    if not user: raise HTTPException(404, detail="user not found")
     sig_member = SIGMember(
         ig_id=id,
         user_id=body.user_id,
         status=sig.status
     )
     session.add(sig_member)
-    try:
-        session.commit()
+    try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(status_code=409, detail="unique field already exists")
+        raise HTTPException(409, detail="unique field already exists")
     return
 
 
@@ -265,16 +235,12 @@ class BodyExecutiveLeaveSIG(BaseModel):
 @sig_router.post('/executive/sig/{id}/member/leave', status_code=204)
 async def executive_leave_sig(id: int, body: BodyExecutiveLeaveSIG, session: SessionDep):
     sig = session.get(SIG, id)
-    if not sig:
-        raise HTTPException(status_code=404, detail="sig not found")
+    if not sig: raise HTTPException(404, detail="sig not found")
     user = session.get(User, body.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="user not found")
-    if sig.owner == user.id:
-        raise HTTPException(status_code=409, detail="sig owner cannot leave the sig")
+    if not user: raise HTTPException(404, detail="user not found")
+    if sig.owner == user.id: raise HTTPException(409, detail="sig owner cannot leave the sig")
     sig_members = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == body.user_id)).all()
-    if not sig_members:
-        raise HTTPException(status_code=404, detail="sig member not found")
+    if not sig_members: raise HTTPException(404, detail="sig member not found")
     for member in sig_members:
         session.delete(member)
     session.commit()
@@ -302,15 +268,13 @@ _valid_sig_global_status_update = (
 
 def _check_valid_sig_global_status_update(old_status: SIGStatus, new_status: SIGStatus) -> bool:
     for valid_update in _valid_sig_global_status_update:
-        if (old_status, new_status) == valid_update:
-            return True
+        if (old_status, new_status) == valid_update: return True
     return False
 
 
 @sig_router.post('/executive/sig/global/status', status_code=204)
 async def update_sig_global_status(body: BodyUpdateSIGGlobalStatus, session: SessionDep, sig_global_status: SIGGlobalStatus = Depends(get_sig_global_status)):
-    if not _check_valid_sig_global_status_update(sig_global_status.status, body.status):
-        raise HTTPException(400, "invalid sig global status update")
+    if not _check_valid_sig_global_status_update(sig_global_status.status, body.status): raise HTTPException(400, "invalid sig global status update")
     if body.status == SIGStatus.inactive:
         sigs = session.exec(select(SIG).where(SIG.status != SIGStatus.inactive)).all()
         for sig in sigs:

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -1,2 +1,3 @@
 from .sha256 import sha256_hash
 from .validator import is_valid_phone, is_valid_student_id, is_valid_year, is_valid_semester
+from .get_ig_global_status import get_sig_global_status, get_pig_global_status

--- a/src/util/get_ig_global_status.py
+++ b/src/util/get_ig_global_status.py
@@ -1,0 +1,18 @@
+from fastapi import HTTPException
+
+from src.db import SessionDep
+from src.model import PIGGlobalStatus, SIGGlobalStatus
+
+
+def get_sig_global_status(session: SessionDep) -> SIGGlobalStatus:
+    status = session.get(SIGGlobalStatus, 1)
+    if status is None:
+        raise HTTPException(status_code=503, detail="sig global status does not exist")
+    return status
+
+
+def get_pig_global_status(session: SessionDep) -> PIGGlobalStatus:
+    status = session.get(PIGGlobalStatus, 1)
+    if status is None:
+        raise HTTPException(status_code=503, detail="pig global status does not exist")
+    return status

--- a/src/util/get_ig_global_status.py
+++ b/src/util/get_ig_global_status.py
@@ -6,13 +6,11 @@ from src.model import PIGGlobalStatus, SIGGlobalStatus
 
 def get_sig_global_status(session: SessionDep) -> SIGGlobalStatus:
     status = session.get(SIGGlobalStatus, 1)
-    if status is None:
-        raise HTTPException(status_code=503, detail="sig global status does not exist")
+    if status is None: raise HTTPException(503, detail="sig global status does not exist")
     return status
 
 
 def get_pig_global_status(session: SessionDep) -> PIGGlobalStatus:
     status = session.get(PIGGlobalStatus, 1)
-    if status is None:
-        raise HTTPException(status_code=503, detail="pig global status does not exist")
+    if status is None: raise HTTPException(503, detail="pig global status does not exist")
     return status


### PR DESCRIPTION
## 임원 등 조회 기능
- 임원(executive) 조회: `GET /api/user/executives`
- 회장(president) 조회: `GET /api/user/presidents`

## SIG/PIG 전역 상태 기능
- sig_global_status 테이블 정의
- 상태는 inactive -> surveying -> recruiting -> active, any -> inactive 변경만 허용
- 상태에 따라 허용되는 기능이 다름:
  * 시그 생성: surveying에서만 가능
  * 시그 가입: surveying/recruiting에서만 가능
  * 관리자 경로는 상태와 무관하게 작동함
- 상태 조회: `GET /api/sig/global/status`
- 상태 변경: `GET /api/executive/sig/global/status`

## 이미지 업로드, 다운로드 기능
- `docs/image.md`: api 문서 및 이미지 메타데이터 DB 설계
- `README.md`: 이미지 기능 관련 env 변수 정의

## 기타
- user api docs의 phone, student_id 예시 데이터의 형식이 맞지 않은 부분 수정
- 위 기능 구현을 위한 sql 관련 설정
- pylint, autopep8 "--max-line-length=200" 설정에 맞게 formatting