### PR TITLE
Feat(banking): added open banking api features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ FILE_MAX_SIZE=10000000
 | `IMAGE_MAX_SIZE`   | 이미지 최대 용량(바이트) |
 | `FILE_DIR`        | 파일 업로드 경로. 폴더가 이미 생성되어 있어야 함 |
 | `FILE_MAX_SIZE`   | 파일 최대 용량(바이트) |
+| `OPENBANK_CLIENT_ID`  |  금융결제원 오픈 API 개발자사이트 > 마이페이지 > API Key 관리 > API Key 기본정보 > Client ID |
+| `OPENBANK_CLIENT_SECRET`  | 금융결제원 오픈 API 개발자사이트 > 마이페이지 > API Key 관리 > API Key 기본정보 > Client Secret |
+| `OPENBANK_USERCODE`  |  금융결제원 오픈 API 개발자사이트 > 마이페이지 > 회원정보 관리 > 이용기관코드 |
 
 ## 실행 방법(with docker)
 

--- a/docs/bank.md
+++ b/docs/bank.md
@@ -1,0 +1,82 @@
+# 오픈뱅킹 관련 DB, API 명세서
+**최신개정일** 2025-06-18
+
+# DB 구조
+
+## 계좌 정보 DB
+```sql
+CREATE TABLE banking_account_details (
+    id INT NOT NULL PRIMARY KEY DEFAULT 1,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NOT NULL,
+    user_seq_no VARCHAR(64) NOT NULL,
+    access_token_expire DATETIME NOT NULL,
+    scope VARCHAR(255) NOT NULL,
+    fintech_use_num VARCHAR(32),
+    tran_id_tail INT,
+    CONSTRAINT ck_id_valid CHECK (id = 1)
+);
+```
+후술되는 Open API의 OAuth 기작을 통해서만 등록되며, 동아리 계좌 한 종류만 등록되어야 함.
+
+# API 구조
+
+## 오픈뱅킹 API 사용 관련 API(/api/bank)
+
+- 오픈뱅킹 API를 통해 동아리 계좌를 등록하고,
+- 동아리 계좌의 입금내역을 확인함.
+
+유의사항
+- 테스트 시 open api uri를 `testapi`로 사용, 실제 배포 시 `openapi`로 변경
+- 개발자 사이트에서 테스트 권한이 아직 부여되지 않아 내부 로직 테스트는 아직 안됨
+
+## 🔹 동아리 계좌 등록용 OAuth2.0 URL 생성
+
+- **Method**: `GET`  
+- **URL**: `/api/bank/auth-url`
+- **설명**: oauth url 생성, 동아리 회장만 접근 가능
+- **Request Body**:
+None
+
+- **Response**:
+```json
+{
+    "auth_url": "https://testapi.openbanking.or.kr/oauth/2.0/authorize?response_type=code&client_id=...&redirect_uri=http://localhost:8080/bank/callback&scope=login%20inquiry&state=...&auth_type=0"
+}
+```
+- **Status Codes**:
+  - `200 OK`
+  - `401 Unauthorized`
+  - `403 Forbidden` (회장 권한 없음)
+
+
+---
+
+## 🔹 입금 확인
+
+- **Method**: `GET`  
+- **URL**: `/api/bank/inquiry`  
+- **설명**: 지정된 기간 내 동아리 계좌에 입금 여부 확인
+- **Request Body**:
+```json
+{
+    "depositer": "입금자명",
+    "from_date": "20250618",
+    "to_date": "20250618"
+}
+```
+- **Response**:
+```json
+{
+  "trx_true": "true"
+}
+```
+- **Status Codes**:
+  - `200 OK`
+  - `400 Bad Request` (파라미터 등 이슈로 토큰 리퀘스트 실패)
+  - `401 Unauthorized` (권한 부족)
+  - `404 Not Found` (등록된 동아리 계좌가 없음, 또는 토큰이 없음)
+
+---
+
+TODO: 테스트 권한을 발급받아 로직 구현 마무리

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -11,6 +11,9 @@ class Settings(BaseSettings):
     image_max_size: int
     file_dir: str
     file_max_size: int
+    openbank_client_id: str
+    openbank_client_secret: str
+    openbank_usercode: str
 
     model_config = SettingsConfigDict(env_file=".env", frozen=True)
 

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -5,3 +5,4 @@ from .scsc_global_status import SCSCStatus, SCSCGlobalStatus
 from .pig import PIG, PIGMember
 from .sig import SIG, SIGMember
 from .user import User, UserRole, UserStatus
+from .bank import BankingAccountDetails

--- a/src/model/bank.py
+++ b/src/model/bank.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timezone
+
+from sqlmodel import CheckConstraint, Field, SQLModel
+from typing import Optional
+
+
+class BankingAccountDetails(SQLModel, table=True):
+    __tablename__ = "banking_account_details"  # type: ignore
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_id_valid"),
+    )
+
+    id: int = Field(default=1, nullable=False, primary_key=True)
+    access_token: str = Field(nullable=False)
+    refresh_token: str = Field(nullable=False)
+    user_seq_no: str = Field(nullable=False)
+    access_token_expire: datetime = Field(nullable=False)
+    scope: str = Field(nullable=False)
+    fintech_use_num: Optional[str] = Field(default=None)
+    tran_id_tail: Optional[int] = Field(default=None)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -9,6 +9,7 @@ from .article import article_router
 from .board import board_router
 from .file import file_router
 from .scsc import scsc_router
+from .bank import bank_router
 
 root_router = APIRouter()
 
@@ -21,3 +22,4 @@ root_router.include_router(article_router, prefix='/api')
 root_router.include_router(board_router, prefix='/api')
 root_router.include_router(file_router, prefix='/api')
 root_router.include_router(scsc_router, prefix='/api')
+root_router.include_router(bank_router) # no prefix due to redirection logic

--- a/src/routes/bank.py
+++ b/src/routes/bank.py
@@ -1,0 +1,147 @@
+from fastapi import APIRouter, HTTPException
+import os
+from datetime import datetime, timedelta, timezone
+import httpx
+import random
+
+from src.model import BankingAccountDetails
+from src.db import SessionDep
+
+CLIENT_ID = os.getenv("OPENBANK_CLIENT_ID")
+CLIENT_SECRET = os.getenv("OPENBANK_CLIENT_SECRET")
+USERCODE=os.getenv("OPENBANK_USERCODE")
+API_SECRET=os.getenv("API_SECRET")
+
+bank_router = APIRouter(tags=['bank'])
+
+# only the **president** should have permission for this
+@bank_router.get("/api/bank/auth-url")
+async def get_oauth_url():
+    base_url = "https://testapi.openbanking.or.kr/oauth/2.0/authorize" # change later from testapi to openapi
+
+    client_id = CLIENT_ID
+    redirect_uri = "http://localhost:8080/bank/callback" # change host later, no api prefix for this
+    scope = "login%20inquiry"
+    state = ''.join([str(random.choice(range(10))) for _ in range(32)]) # random 32-byte
+    auth_type = "0"
+
+    query_string = (f"?response_type=code"f"&client_id={client_id}"f"&redirect_uri={redirect_uri}"f"&scope={scope}"f"&state={state}"f"&auth_type={auth_type}")
+
+    url = base_url + query_string
+
+    return {"auth_url": url}
+
+
+# only accessible through callback
+@bank_router.get("/bank/callback")
+async def oauth_callback(code: str, scope: str, state: str, session: SessionDep):
+    token_url = "https://testapi.openbanking.or.kr/oauth/2.0/token" # change from testapi to openapi later
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(token_url, data={"code": code, "client_id": CLIENT_ID, "client_secret": CLIENT_SECRET, "redirect_uri": "http://localhost:8080/bank/callback", "grant_type": "authorization_code"})
+
+    if response.status_code != 200 or response.json()["rsp_code"]:
+        raise HTTPException(status_code=400, detail="token request failed")
+
+    data = response.json()
+
+    banking_data = BankingAccountDetails(
+        id=1,
+        access_token = data["access_token"],
+        refresh_token = data["refresh_token"],
+        user_seq_no = data["user_seq_no"],
+        access_token_expire = datetime.now(timezone.utc) + timedelta(seconds=int(data["expires_in"])),
+        scope = data["scope"]
+    )
+    
+    session.add(banking_data)
+    session.commit()
+
+    return {"message": "token properly requested and saved to db"}
+
+
+
+async def get_valid_access_token(session: SessionDep):
+    data = session.get(BankingAccountDetails, 1)
+    if not data: raise HTTPException(404, detail="deposit account not found")
+    token = data.access_token
+    fintech_use_num = data.fintech_use_num
+
+    if data.access_token_expire > datetime.now():
+        if fintech_use_num:
+            return token, fintech_use_num
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.get("https://testapi.openbanking.or.kr/v2.0/user/me", headers={"Authorization": "Bearer "+token["access_token"]}, data={"user_seq_no": token["user_seq_no"]})
+            
+        if response.status_code != 200 or response.json()["rsp_code"]:
+            raise HTTPException(status_code=404, detail="user data request failed")
+        
+        data.fintech_use_num = response.json()["res_list"][0]["fintech_use_num"]
+        session.add(data)
+        session.commit()
+            
+        return token, response.json()["res_list"][0]["fintech_use_num"]
+
+    token_url = "https://testapi.openbanking.or.kr/oauth/2.0/token" # change from testapi to openapi later
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(token_url, data={"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET, "refresh_token": data.refresh_token, "scope": "login inquiry", "grant_type": "refresh_token"})
+    
+    if response.status_code != 200 or response.json()["rsp_code"]:
+        raise HTTPException(status_code=400, detail="token request failed")
+
+    new_data = response.json()
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://testapi.openbanking.or.kr/v2.0/user/me", headers={"Authorization": "Bearer "+new_data["access_token"]}, data={"user_seq_no": new_data["user_seq_no"]})
+        
+    if response.status_code != 200 or response.json()["rsp_code"]:
+        raise HTTPException(status_code=400, detail="user data request failed")
+    
+    data.fintech_use_num = response.json()["res_list"][0]["fintech_use_num"]
+    session.add(data)
+    
+    banking_data = BankingAccountDetails(
+        id=1,
+        access_token = new_data["access_token"],
+        refresh_token = new_data["refresh_token"],
+        user_seq_no = new_data["user_seq_no"],
+        access_token_expire = datetime.now(timezone.utc) + timedelta(seconds=int(new_data["expires_in"])),
+        scope = new_data["scope"]
+    )
+    
+    session.add(banking_data)
+    session.commit()
+
+    return new_data["access_token"], response.json()["res_list"][0]["fintech_use_num"]
+
+
+@bank_router.get("/api/bank/inquiry")
+async def get_user_payment(depositer: str, from_date: str, to_date: str, session: SessionDep):
+    trx_url = "https://testapi.openbanking.or.kr/v2.0/account/transaction_list/fin_num"
+    
+    token, fintech_use_num = await get_valid_access_token()
+    
+    data = session.get(BankingAccountDetails, 1)
+    if not data: raise HTTPException(404, detail="deposit account not found")
+    
+    if not data.tran_id_tail: data.tran_id_tail = 0
+    data.tran_id_tail = (data.tran_id_tail + random.choice((1, 2, 3))) % 1000000000
+    tran_id = str(USERCODE) + 'U' + f'{data.tran_id_tail:09}'
+    session.add(data)
+    session.commit()
+    
+    now = datetime.now()
+    formatted_datetime = now.strftime("%Y%m%d%H%M%S")
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.get(trx_url, headers= {"Authorization": "Bearer "+token}, data={"bank_tran_id": tran_id, "fintech_use_num": fintech_use_num, "inquiry_type": "I", "inquiry_base": "D", "from_date": from_date, "to_date": to_date, "sort_order": "D", "tran_dtime": formatted_datetime})
+    
+    if response.status_code != 200 or response.json()["rsp_code"]:
+        raise HTTPException(status_code=400, detail="inquiry failed")
+    
+    for deposit_hist in response.json()["res_list"]:
+        if deposit_hist["depositer"] == depositer:
+            return {"trx_true": "true"}
+    return {"trx_true": "false"}


### PR DESCRIPTION
# 금융결제원 오픈 API 관련 로직 구현
## OAuth2.0 로그인
- 생성된 URL에 접속하여 동아리 회장이 동아리 계좌 한 개를 등록
- 등록 성공 후 redirect_uri에서 token 발급, db에 저장(redirect uri이므로 /api prefix 제거함)

## 입금 내역 확인
- 지정된 날짜 범위 내에 입금 내역을 오픈 API를 통해 반환 받음
- 지정된 입금자명과 겹치는 적합한 입금 내역 존재 여부 확인

## 파일 변경 사항
- `/model`과 `/routes`에 오픈뱅킹 관련 파일 추가
- `.env` 파일에 오픈뱅킹 관련 변수 추가

## 유의사항
- 금융결제원 개발자 사이트가 개인 개발자에게 API 테스트 권한을 기본으로 제공하지 않음. 따라서 아직 입금 내역 확인 로직은 테스트되지 않음.