### PR TITLE
fix: do not use assert permission on OPTION method

### DIFF
--- a/src/middleware/assert_permission.py
+++ b/src/middleware/assert_permission.py
@@ -7,6 +7,8 @@ from src.util import get_user, get_user_role_level
 
 class AssertPermissionMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        if not request.url.path.startswith('/api') or request.method not in ('GET', 'POST'):
+            return await call_next(request)
         if request.url.path.startswith("/api/executive"):
             try:
                 current_user = get_user(request)


### PR DESCRIPTION
executive 경로로 OPTION 요청이 왔을 때 401을 반환하는 오류 해결