### PR TITLE
fix: allow creating sig without discord_id, koreanize error messages

### DIFF
--- a/script/clear_db.sh
+++ b/script/clear_db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+rm ../db/*.db && 
+rm ../static/article/*.md && 
+echo "successfully removed database files"

--- a/script/insert_president_users.sh
+++ b/script/insert_president_users.sh
@@ -20,14 +20,17 @@ generate_hash() {
 }
 
 # Sample user data
+DISCORD_BOT_EMAIL="bot@discord.com"
 EMAIL2="zizonms@snu.ac.kr"
 EMAIL3="tteokgook1@snu.ac.kr"
+DISCORD_BOT_ID=$(generate_hash "$DISCORD_BOT_EMAIL")
 ID2=$(generate_hash "$EMAIL2")
 ID3=$(generate_hash "$EMAIL3")
 
 sqlite3 "$DB_FILE" <<EOF
 INSERT INTO user (id, email, name, phone, student_id, role, status, last_login, created_at, updated_at, major_id)
 VALUES
+  ('$DISCORD_BOT_ID', '$DISCORD_BOT_EMAIL', 'Discord Bot', '01000000000', '202500000', 1000, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1),
   ('$ID2', '$EMAIL2', '강명석', '09900000002', '200000002', 1000, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1),
   ('$ID3', '$EMAIL3', '이한경', '09900000003', '200000003', 1000, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1);
 EOF

--- a/script/insert_sample_users.sh
+++ b/script/insert_sample_users.sh
@@ -26,8 +26,6 @@ EMAIL3="president@example.com"
 EMAIL4="member@example.com"
 EMAIL5="oldboy@example.com"
 EMAIL6="dormant@example.com"
-EMAIL7="lowest@example.com"
-DISCORD_BOT_EMAIL="bot@discord.com"
 
 ID1=$(generate_hash "$EMAIL1")
 ID2=$(generate_hash "$EMAIL2")
@@ -35,8 +33,6 @@ ID3=$(generate_hash "$EMAIL3")
 ID4=$(generate_hash "$EMAIL4")
 ID5=$(generate_hash "$EMAIL5")
 ID6=$(generate_hash "$EMAIL6")
-ID7=$(generate_hash "$EMAIL7")
-DISCORD_BOT_ID=$(generate_hash "$DISCORD_BOT_EMAIL")
 
 sqlite3 "$DB_FILE" <<EOF
 INSERT INTO user (id, email, name, phone, student_id, role, status, last_login, created_at, updated_at, major_id)
@@ -46,9 +42,7 @@ VALUES
   ('$ID3', '$EMAIL3', 'Carol Choi', '01034567890', '202512347', 1000, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1),
   ('$ID4', '$EMAIL4', 'David Park', '01045678901', '202512348', 300, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2),
   ('$ID5', '$EMAIL5', 'Eunseo Han', '01056789012', '202512349', 400, 'banned', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2),
-  ('$ID6', '$EMAIL6', 'Gyuri Seo', '01067890123', '202512350', 100, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3),
-  ('$ID7', '$EMAIL7', 'Hyunwoo Jang', '01078901234', '202512351', 300, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3),
-  ('$DISCORD_BOT_ID', '$DISCORD_BOT_EMAIL', 'Discord Bot', '01000000000', '202500000', 1000, 'pending', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1);
+  ('$ID6', '$EMAIL6', 'Gyuri Seo', '01067890123', '202512350', 100, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3);
 EOF
 
 echo "Sample users and discord bot user inserted successfully into '$DB_FILE'."

--- a/src/controller/pig.py
+++ b/src/controller/pig.py
@@ -18,7 +18,7 @@ class BodyCreatePIG(BaseModel):
     content: str
 
 
-async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str, user_discord_id: int, scsc_global_status: SCSCGlobalStatus) -> PIG:
+async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> PIG:
     if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"cannot create pig when pig global status is not in {ctrl_status_available.create_sigpig}")
 
     pig_article = await create_article_ctrl(
@@ -53,7 +53,7 @@ async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str
     session.add(pig_member)
     session.commit()
     session.refresh(pig)
-    await send_discord_bot_request_no_reply(action_code=4003, body={'pig_name': body.title, 'user_id_list': [user_discord_id]})
+    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4003, body={'pig_name': body.title, 'user_id_list': [user_discord_id]})
     return pig
 
 

--- a/src/controller/pig.py
+++ b/src/controller/pig.py
@@ -53,7 +53,7 @@ async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str
     session.add(pig_member)
     session.commit()
     session.refresh(pig)
-    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4003, body={'pig_name': body.title, 'user_id_list': [user_discord_id]})
+    await send_discord_bot_request_no_reply(action_code=4003, body={'pig_name': body.title, 'user_id_list': ([user_discord_id] if user_discord_id else [])})
     return pig
 
 

--- a/src/controller/pig.py
+++ b/src/controller/pig.py
@@ -19,7 +19,7 @@ class BodyCreatePIG(BaseModel):
 
 
 async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> PIG:
-    if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"cannot create pig when pig global status is not in {ctrl_status_available.create_sigpig}")
+    if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.create_sigpig}일 때만 시그/피그를 생성할 수 있습니다")
 
     pig_article = await create_article_ctrl(
         session,
@@ -41,7 +41,7 @@ async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(pig)
 
     if pig.id is None: raise HTTPException(503, detail="pig primary key does not exist")
@@ -66,8 +66,8 @@ class BodyUpdatePIG(BaseModel):
 
 async def update_pig_ctrl(session: SessionDep, id: int, body: BodyUpdatePIG, user_id: str, is_executive: bool) -> None:
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
-    if not is_executive and pig.owner != user_id: raise HTTPException(status_code=403, detail="cannot update pig of other")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
+    if not is_executive and pig.owner != user_id: raise HTTPException(status_code=403, detail="타인의 시그/피그를 변경할 수 없습니다")
 
     if body.title: pig.title = body.title
     if body.description: pig.description = body.description
@@ -80,12 +80,12 @@ async def update_pig_ctrl(session: SessionDep, id: int, body: BodyUpdatePIG, use
         )
         pig.content_id = pig_article.id
     if body.status:
-        if not is_executive: raise HTTPException(403, detail="Only executive and above can update status")
+        if not is_executive: raise HTTPException(403, detail="관리자 이상의 권한이 필요합니다")
         pig.status = body.status
 
     session.add(pig)
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     return

--- a/src/controller/sig.py
+++ b/src/controller/sig.py
@@ -18,7 +18,7 @@ class BodyCreateSIG(BaseModel):
     content: str
 
 
-async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str, user_discord_id: int, scsc_global_status: SCSCGlobalStatus) -> SIG:
+async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> SIG:
     if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"cannot create sig when sig global status is not in {ctrl_status_available.create_sigpig}")
 
     sig_article = await create_article_ctrl(
@@ -53,7 +53,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
     session.add(sig_member)
     session.commit()
     session.refresh(sig)
-    await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': [user_discord_id]})
+    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': [user_discord_id]})
     return sig
 
 

--- a/src/controller/sig.py
+++ b/src/controller/sig.py
@@ -19,7 +19,7 @@ class BodyCreateSIG(BaseModel):
 
 
 async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> SIG:
-    if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"cannot create sig when sig global status is not in {ctrl_status_available.create_sigpig}")
+    if scsc_global_status.status not in ctrl_status_available.create_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.create_sigpig}일 때만 시그/피그를 생성할 수 있습니다")
 
     sig_article = await create_article_ctrl(
         session,
@@ -41,7 +41,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(sig)
 
     if sig.id is None: raise HTTPException(503, detail="sig primary key does not exist")
@@ -66,8 +66,8 @@ class BodyUpdateSIG(BaseModel):
 
 async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, user_id: str, is_executive: bool) -> None:
     sig = session.get(SIG, id)
-    if not sig: raise HTTPException(404, detail="sig not found")
-    if not is_executive and sig.owner != user_id: raise HTTPException(status_code=403, detail="cannot update sig of other")
+    if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
+    if not is_executive and sig.owner != user_id: raise HTTPException(status_code=403, detail="타인의 시그/피그를 변경할 수 없습니다")
 
     if body.title: sig.title = body.title
     if body.description: sig.description = body.description
@@ -80,12 +80,12 @@ async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, use
         )
         sig.content_id = sig_article.id
     if body.status:
-        if not is_executive: raise HTTPException(403, detail="Only executive and above can update status")
+        if not is_executive: raise HTTPException(403, detail="관리자 이상의 권한이 필요합니다")
         sig.status = body.status
 
     session.add(sig)
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     return

--- a/src/controller/sig.py
+++ b/src/controller/sig.py
@@ -53,7 +53,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
     session.add(sig_member)
     session.commit()
     session.refresh(sig)
-    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': [user_discord_id]})
+    await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': ([user_discord_id] if user_discord_id else [])})
     return sig
 
 

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -22,7 +22,7 @@ async def create_pig(session: SessionDep, scsc_global_status: SCSCGlobalStatusDe
 @pig_router.get('/pig/{id}')
 async def get_pig_by_id(id: int, session: SessionDep) -> PIG:
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     return pig
 
 
@@ -41,7 +41,7 @@ async def update_my_pig(id: int, session: SessionDep, request: Request, body: Bo
 async def delete_my_pig(id: int, session: SessionDep, request: Request) -> None:
     current_user = get_user(request)
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if pig.owner != current_user.id: raise HTTPException(403, detail="cannot delete pig of other")
     session.delete(pig)
     session.commit()
@@ -57,7 +57,7 @@ async def update_pig(id: int, session: SessionDep, request: Request, body: BodyU
 @pig_router.post('/executive/pig/{id}/delete', status_code=204)
 async def delete_pig(id: int, session: SessionDep) -> None:
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     session.delete(pig)
     session.commit()
     return
@@ -74,9 +74,8 @@ async def handover_pig(id: int, session: SessionDep, request: Request, body: Bod
     if pig is None: raise HTTPException(404, detail="no pig exists")
     user = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(
         PIGMember.user_id == body.new_owner)).first()
-    if not user: raise HTTPException(
-        status_code=404, detail="new_owner should be a member of the pig")
-    if current_user.role < get_user_role_level('executive') and current_user.id != pig.owner: raise HTTPException(403, "handover can be executed only by executive or owner of the pig")
+    if not user: raise HTTPException(status_code=404, detail="새로운 시그/피그장은 해당 시그/피그의 구성원이어야 합니다")
+    if current_user.role < get_user_role_level('executive') and current_user.id != pig.owner: raise HTTPException(403, "타인의 시그/피그를 변경할 수 없습니다")
     pig.owner = body.new_owner
     session.add(pig)
     session.commit()
@@ -92,7 +91,7 @@ async def get_pig_members(id: int, session: SessionDep) -> Sequence[PIGMember]:
 async def join_pig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"cannot join to pig when pig status is not in {ctrl_status_available.join_sigpig}")
     pig_member = PIGMember(
         ig_id=id,
@@ -103,7 +102,7 @@ async def join_pig(id: int, session: SessionDep, request: Request):
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(pig)
     if current_user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': current_user.discord_id, 'role_name': pig.title})
     return
@@ -113,10 +112,10 @@ async def join_pig(id: int, session: SessionDep, request: Request):
 async def leave_pig(id: int, session: SessionDep, scsc_global_status: SCSCGlobalStatusDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
-    if pig.owner == current_user.id: raise HTTPException(409, detail="pig owner cannot leave the pig")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
+    if pig.owner == current_user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
     pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id).where(PIGMember.status == scsc_global_status.status)).first()
-    if not pig_member: raise HTTPException(404, detail="pig member not found")
+    if not pig_member: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
     session.delete(pig_member)
     session.commit()
     session.refresh(pig)
@@ -131,9 +130,9 @@ class BodyExecutiveJoinPIG(BaseModel):
 @pig_router.post('/executive/pig/{id}/member/join', status_code=204)
 async def executive_join_pig(id: int, session: SessionDep, body: BodyExecutiveJoinPIG):
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     user = session.get(User, body.user_id)
-    if not user: raise HTTPException(404, detail="user not found")
+    if not user: raise HTTPException(404, detail="해당 id의 사용자가 없습니다")
     pig_member = PIGMember(
         ig_id=id,
         user_id=body.user_id,
@@ -143,7 +142,7 @@ async def executive_join_pig(id: int, session: SessionDep, body: BodyExecutiveJo
     try: session.commit()
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, detail="unique field already exists")
+        raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(user)
     session.refresh(pig)
     if user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': user.discord_id, 'role_name': pig.title})
@@ -157,12 +156,12 @@ class BodyExecutiveLeavePIG(BaseModel):
 @pig_router.post('/executive/pig/{id}/member/leave', status_code=204)
 async def executive_leave_pig(id: int, session: SessionDep, body: BodyExecutiveLeavePIG):
     pig = session.get(PIG, id)
-    if not pig: raise HTTPException(404, detail="pig not found")
+    if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     user = session.get(User, body.user_id)
-    if not user: raise HTTPException(404, detail="user not found")
-    if pig.owner == user.id: raise HTTPException(409, detail="pig owner cannot leave the pig")
+    if not user: raise HTTPException(404, detail="해당 id의 사용자가 없습니다")
+    if pig.owner == user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
     pig_members = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == body.user_id)).all()
-    if not pig_members: raise HTTPException(404, detail="pig member not found")
+    if not pig_members: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
     for member in pig_members:
         session.delete(member)
     session.commit()

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -42,7 +42,7 @@ async def delete_my_pig(id: int, session: SessionDep, request: Request) -> None:
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if pig.owner != current_user.id: raise HTTPException(403, detail="cannot delete pig of other")
+    if pig.owner != current_user.id: raise HTTPException(403, detail="타인의 시그/피그를 삭제할 수 없습니다")
     session.delete(pig)
     session.commit()
     return
@@ -71,7 +71,7 @@ class BodyHandoverPIG(BaseModel):
 async def handover_pig(id: int, session: SessionDep, request: Request, body: BodyHandoverPIG) -> None:
     current_user = get_user(request)
     pig = session.get(PIG, id)
-    if pig is None: raise HTTPException(404, detail="no pig exists")
+    if pig is None: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     user = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(
         PIGMember.user_id == body.new_owner)).first()
     if not user: raise HTTPException(status_code=404, detail="새로운 시그/피그장은 해당 시그/피그의 구성원이어야 합니다")
@@ -92,7 +92,7 @@ async def join_pig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"cannot join to pig when pig status is not in {ctrl_status_available.join_sigpig}")
+    if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
     pig_member = PIGMember(
         ig_id=id,
         user_id=current_user.id,

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -16,7 +16,6 @@ pig_router = APIRouter(tags=['pig'])
 @pig_router.post('/pig/create', status_code=201)
 async def create_pig(session: SessionDep, scsc_global_status: SCSCGlobalStatusDep, request: Request, body: BodyCreatePIG) -> PIG:
     current_user = get_user(request)
-    if not current_user.discord_id: raise HTTPException(409, 'No discord ID found, creator must enroll in the discord server first')
     return await create_pig_ctrl(session, body, current_user.id, current_user.discord_id, scsc_global_status)
 
 
@@ -106,8 +105,7 @@ async def join_pig(id: int, session: SessionDep, request: Request):
         session.rollback()
         raise HTTPException(409, detail="unique field already exists")
     session.refresh(pig)
-    if not current_user.discord_id: raise HTTPException(409, 'No discord ID found, user must enroll in the discord server first')
-    await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': current_user.discord_id, 'role_name': pig.title})
+    if current_user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': current_user.discord_id, 'role_name': pig.title})
     return
 
 
@@ -148,8 +146,7 @@ async def executive_join_pig(id: int, session: SessionDep, body: BodyExecutiveJo
         raise HTTPException(409, detail="unique field already exists")
     session.refresh(user)
     session.refresh(pig)
-    if not user.discord_id: raise HTTPException(409, 'No discord ID found, user must enroll in the discord server first')
-    await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': user.discord_id, 'role_name': pig.title})
+    if user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': user.discord_id, 'role_name': pig.title})
     return
 
 

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -16,7 +16,6 @@ sig_router = APIRouter(tags=['sig'])
 @sig_router.post('/sig/create', status_code=201)
 async def create_sig(session: SessionDep, scsc_global_status: SCSCGlobalStatusDep, request: Request, body: BodyCreateSIG) -> SIG:
     current_user = get_user(request)
-    if not current_user.discord_id: raise HTTPException(409, 'No discord ID found, creator must enroll in the discord server first')
     return await create_sig_ctrl(session, body, current_user.id, current_user.discord_id, scsc_global_status)
 
 
@@ -106,8 +105,7 @@ async def join_sig(id: int, session: SessionDep, request: Request):
         session.rollback()
         raise HTTPException(409, detail="unique field already exists")
     session.refresh(sig)
-    if not current_user.discord_id: raise HTTPException(409, 'No discord ID found, user must enroll in the discord server first')
-    await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': current_user.discord_id, 'role_name': sig.title})
+    if current_user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': current_user.discord_id, 'role_name': sig.title})
     return
 
 
@@ -148,8 +146,7 @@ async def executive_join_sig(id: int, session: SessionDep, body: BodyExecutiveJo
         raise HTTPException(409, detail="unique field already exists")
     session.refresh(user)
     session.refresh(sig)
-    if not user.discord_id: raise HTTPException(409, 'No discord ID found, creator must enroll in the discord server first')
-    await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': user.discord_id, 'role_name': sig.title})
+    if user.discord_id: await send_discord_bot_request_no_reply(action_code=2001, body={'user_id': user.discord_id, 'role_name': sig.title})
     return
 
 

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -42,7 +42,7 @@ async def delete_my_sig(id: int, session: SessionDep, request: Request) -> None:
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if sig.owner != current_user.id: raise HTTPException(403, detail="cannot delete sig of other")
+    if sig.owner != current_user.id: raise HTTPException(403, detail="타인의 시그/피그를 삭제할 수 없습니다")
     session.delete(sig)
     session.commit()
     return
@@ -71,7 +71,7 @@ class BodyHandoverSIG(BaseModel):
 async def handover_sig(id: int, session: SessionDep, request: Request, body: BodyHandoverSIG) -> None:
     current_user = get_user(request)
     sig = session.get(SIG, id)
-    if sig is None: raise HTTPException(404, detail="no sig exists")
+    if sig is None: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     user = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(
         SIGMember.user_id == body.new_owner)).first()
     if not user: raise HTTPException(status_code=404, detail="새로운 시그/피그장은 해당 시그/피그의 구성원이어야 합니다")
@@ -92,7 +92,7 @@ async def join_sig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if sig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"cannot join to sig when sig status is not in {ctrl_status_available.join_sigpig}")
+    if sig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
     sig_member = SIGMember(
         ig_id=id,
         user_id=current_user.id,


### PR DESCRIPTION
- 디스코드 연결이 되어있지 않아도 시그 생성이 가능하게 수정
- 시그/피그 라우터 오류 메세지 한국어로 변경
- sample user 스크립트 수정
- clear db 스크립트 작성