### PR TITLE
feat: add manual enroll route

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -555,6 +555,26 @@ ___
 
 ---
 
+## Manually Process Standby Request
+
+- **Method**: `POST`
+- **URL**: `/api/executive/user/standby/process/manual`
+- **Request Body**:
+```json
+{
+  "id": "b36a83701f1c3191e19722d6f90274bc1b5501fe69ebf33313e440fe4b0fe210"
+}
+```
+
+- **Status Codes**:
+  - `204 No Content`: 성공
+  - `401 Unauthorized` (로그인하지 않음)
+  - `403 Forbidden` (관리자(executive) 권한 없음)
+  - `404 Not Found` (사용자가 없음)
+  - `409 Conflict` (이미 active인 사용자에 대해 요청함)
+
+---
+
 ## Process Standby Request List with File
 
 - **Method**: `POST`
@@ -568,7 +588,7 @@ ___
     | file | File | O    | 업로드할 파일 (csv(UTF-8 or EUC-KR)) |
 
 - **Status Codes**:
-  - `200 No Content`: 성공
+  - `200 OK`: 성공
   - `400 Bad Request`: 파일 누락 또는 유효하지 않은 파일 또는 기타 인코딩 문제 또는 입금 내역 오류
   - `401 Unauthorized` (로그인하지 않음)
   - `403 Forbidden` (관리자(executive) 권한 없음)

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -248,7 +248,12 @@ async def process_standby_list_manually(session: SessionDep, request: Request, b
     if user.status == UserStatus.active: raise HTTPException(409, detail="the user is already active")
     user.status = UserStatus.active
     session.add(user)
-    standbyreq = StandbyReqTbl(standby_user_id=user.id, user_name=user.name, deposit_name=f"Manually by {current_user.name}", deposit_time=datetime.now(timezone.utc), is_checked=True)
+    standbyreq = session.exec(select(StandbyReqTbl).where(StandbyReqTbl.standby_user_id == body.id).where(StandbyReqTbl.is_checked == False)).first()
+    if standbyreq:
+        standbyreq.is_checked = True
+        standbyreq.deposit_name = f"Manually by {current_user.name}"
+        standbyreq.deposit_time = datetime.now(timezone.utc)
+    else: standbyreq = StandbyReqTbl(standby_user_id=user.id, user_name=user.name, deposit_name=f"Manually by {current_user.name}", deposit_time=datetime.now(timezone.utc), is_checked=True)
     session.add(standbyreq)
     session.commit()
     return


### PR DESCRIPTION
- `/api/executive/user/standby/process/manual`로 요청을 보내면 해당 사용자의 status를 active로 바꾸고 standbyreqtbl에 기록합니다. 
- deposit_name에는 "Manually by {임원 이름}", deposit_time에는 요청 처리 시각을 기록합니다. 