### PR TITLE
⚡️ check for status when ig delete

### DIFF
--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -46,6 +46,7 @@ async def delete_my_pig(id: int, session: SessionDep, request: Request) -> None:
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if pig.owner != current_user.id: raise HTTPException(403, detail="타인의 시그/피그를 삭제할 수 없습니다")
+    if pig.status == SCSCStatus.inactive: raise HTTPException(400, detail="해당 시그/피그는 이미 비활성 상태입니다")
     pig.status = SCSCStatus.inactive
     session.commit()
     session.refresh(pig)
@@ -69,6 +70,7 @@ async def delete_pig(id: int, session: SessionDep, request: Request) -> None:
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     pig.status = SCSCStatus.inactive
+    if pig.status == SCSCStatus.inactive: raise HTTPException(400, detail="해당 시그/피그는 이미 비활성 상태입니다")
     session.commit()
     session.refresh(pig)
     year = pig.year

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -69,8 +69,8 @@ async def delete_pig(id: int, session: SessionDep, request: Request) -> None:
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    pig.status = SCSCStatus.inactive
     if pig.status == SCSCStatus.inactive: raise HTTPException(400, detail="해당 시그/피그는 이미 비활성 상태입니다")
+    pig.status = SCSCStatus.inactive
     session.commit()
     session.refresh(pig)
     year = pig.year

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -46,6 +46,7 @@ async def delete_my_sig(id: int, session: SessionDep, request: Request) -> None:
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if sig.owner != current_user.id: raise HTTPException(403, detail="타인의 시그/피그를 삭제할 수 없습니다")
+    if sig.status == SCSCStatus.inactive: raise HTTPException(400, detail="해당 시그/피그는 이미 비활성 상태입니다")
     sig.status = SCSCStatus.inactive
     session.commit()
     session.refresh(sig)
@@ -68,6 +69,7 @@ async def delete_sig(id: int, session: SessionDep, request: Request) -> None:
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
+    if sig.status == SCSCStatus.inactive: raise HTTPException(400, detail="해당 시그/피그는 이미 비활성 상태입니다")
     sig.status = SCSCStatus.inactive
     session.commit()
     session.refresh(sig)


### PR DESCRIPTION
- fixes #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation on SIG/PIG deletion to block actions on already inactive items; requests return HTTP 400 with message: "해당 시그/피그는 이미 비활성 상태입니다".
* **Bug Fixes**
  * Ensured consistent handling for both user and admin deletion endpoints so inactive SIGs/PIGs are rejected early, preventing further processing, notifications, or state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->