### PR TITLE
🚑️ 전역 상태 수정에 따른 시그 등 상태 수정

### DIFF
--- a/src/controller/scsc.py
+++ b/src/controller/scsc.py
@@ -87,6 +87,15 @@ async def update_scsc_global_status_ctrl(session: SessionDep, current_user_id: s
             pig.status = SCSCStatus.recruiting
             session.add(pig)
 
+    # start of active
+    if new_status == SCSCStatus.active:
+        for sig in session.exec(select(SIG).where(SIG.status == SCSCStatus.recruiting)).all():
+            sig.status = SCSCStatus.active
+            session.add(sig)
+        for pig in session.exec(select(PIG).where(PIG.status == SCSCStatus.recruiting)).all():
+            pig.status = SCSCStatus.active
+            session.add(pig)
+
     # end of active
     if scsc_global_status.status == SCSCStatus.active:
         # update previous semester data

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -141,12 +141,13 @@ async def leave_pig(id: int, session: SessionDep, request: Request):
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if pig.owner == current_user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
-    pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id)).first()
-    if not pig_member: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
-    session.delete(pig_member)
+    pig_members = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id)).all()
+    if not pig_members: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
+    for member in pig_members:
+        session.delete(member)
     session.commit()
     session.refresh(pig)
-    await send_discord_bot_request_no_reply(action_code=2002, body={'user_id': current_user.discord_id, 'role_name': pig.title})
+    if current_user.discord_id: await send_discord_bot_request_no_reply(action_code=2002, body={'user_id': current_user.discord_id, 'role_name': pig.title})
     logger.info(f'info_type=pig_leave ; pig_id={pig.id} ; title={pig.title} ; executor_id={current_user.id} ; left_user_id={current_user.id} ; year={pig.year} ; semester={pig.semester}')
     return
 

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -136,12 +136,12 @@ async def join_pig(id: int, session: SessionDep, request: Request):
 
 
 @pig_router.post('/pig/{id}/member/leave', status_code=204)
-async def leave_pig(id: int, session: SessionDep, scsc_global_status: SCSCGlobalStatusDep, request: Request):
+async def leave_pig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if pig.owner == current_user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
-    pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id).where(PIGMember.status == scsc_global_status.status)).first()
+    pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id)).first()
     if not pig_member: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
     session.delete(pig_member)
     session.commit()

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -136,12 +136,12 @@ async def join_sig(id: int, session: SessionDep, request: Request):
 
 
 @sig_router.post('/sig/{id}/member/leave', status_code=204)
-async def leave_sig(id: int, session: SessionDep, scsc_global_status: SCSCGlobalStatusDep, request: Request):
+async def leave_sig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     if sig.owner == current_user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
-    sig_member = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == current_user.id).where(SIGMember.status == scsc_global_status.status)).first()
+    sig_member = session.exec(select(SIGMember).where(SIGMember.ig_id == id).where(SIGMember.user_id == current_user.id)).first()
     if not sig_member: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
     session.delete(sig_member)
     session.commit()


### PR DESCRIPTION
scsc_global_status가 active로 바뀌면 시그/피그 상태가 active로 바뀌어야 하는데 바뀌지 않던 문제를 수정함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When global status becomes Active, groups previously in Recruiting are automatically set to Active for consistent displays and notifications.

* **Behavior Changes**
  * Users can leave SIGs and PIGs regardless of global status; leaving now removes all of a user’s matching memberships for that group and returns 404 if none exist.
  * Discord notifications on leave are only sent when the user has a linked Discord account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->