### PR TITLE
✨ 시그 등 가입 기간 자유화 기능 구현

### DIFF
--- a/docs/sigpig.md
+++ b/docs/sigpig.md
@@ -77,12 +77,14 @@ CREATE INDEX idx_pig_member_ig ON pig_member(ig_id);
 ```sql
 CREATE TRIGGER update_sig_updated_at
 AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON sig 
+FOR EACH ROW
 BEGIN 
     UPDATE sig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
 
 CREATE TRIGGER update_pig_updated_at
 AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON pig 
+FOR EACH ROW
 BEGIN 
     UPDATE pig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
@@ -111,7 +113,7 @@ END;
   "title": "AI SIG",
   "description": "인공지능을 연구하는 소모임입니다.",
   "content": "## 안녕하세요",
-  "is_rolling_admission":false,
+  "is_rolling_admission": false,
 }
 ```
 
@@ -129,7 +131,7 @@ END;
   "created_at": "2025-03-01T10:00:00Z",
   "updated_at": "2025-04-01T12:00:00Z",
   "owner": "hash_of_owner_user",
-  "is_rolling_admission":false,
+  "is_rolling_admission": false,
 }
 ```
 
@@ -160,7 +162,9 @@ END;
   "semester": 1,
   "created_at": "2025-03-01T10:00:00Z",
   "updated_at": "2025-04-01T12:00:00Z",
-  "owner": "hash_of_owner_user"
+  "owner": "hash_of_owner_user",
+  "should_extend": true,
+  "is_rolling_admission": true,
 }
 ```
 
@@ -189,7 +193,9 @@ END;
     "semester": 1,
     "created_at": "2025-03-01T10:00:00Z",
     "updated_at": "2025-04-01T12:00:00Z",
-    "owner": "hash_of_owner_user"
+    "owner": "hash_of_owner_user",
+    "should_extend": true,
+    "is_rolling_admission": true,
   },
   ...
 ]
@@ -213,7 +219,7 @@ END;
   "description": "업데이트된 설명입니다.",
   "content": "### 안녕하세요",
   "should_extend": true,
-  "is_rolling_admission":true,
+  "is_rolling_admission": true,
 }
 ```
 
@@ -280,7 +286,7 @@ END;
   "content": "### 안녕하세요",
   "status": "recruiting",
   "should_extend": true,
-  "is_rolling_admission":true,
+  "is_rolling_admission": true,
 }
 ```
 

--- a/docs/sigpig.md
+++ b/docs/sigpig.md
@@ -1,5 +1,5 @@
 # SIG/PIG 관련 DB, API 명세서
-**최신개정일:** 2025-09-17
+**최신개정일:** 2025-09-19
 
 # DB 구조
 
@@ -15,6 +15,7 @@ CREATE TABLE sig (
     semester INTEGER NOT NULL CHECK (semester IN (1, 2, 3, 4)),
 
     should_extend BOOLEAN NOT NULL DEFAULT FALSE,
+    is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE,
 
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -65,6 +66,8 @@ CREATE TABLE pig_member (
 ```sql
 CREATE INDEX idx_sig_owner ON sig(owner);
 CREATE INDEX idx_sig_term ON sig(year, semester);
+CREATE INDEX idx_pig_owner ON pig(owner);
+CREATE INDEX idx_pig_term ON pig(year, semester);
 CREATE INDEX idx_sig_member_user ON sig_member(user_id);
 CREATE INDEX idx_sig_member_ig ON sig_member(ig_id);
 CREATE INDEX idx_pig_member_user ON pig_member(user_id);
@@ -73,39 +76,15 @@ CREATE INDEX idx_pig_member_ig ON pig_member(ig_id);
 
 ```sql
 CREATE TRIGGER update_sig_updated_at
-AFTER UPDATE ON sig
-FOR EACH ROW
-WHEN 
-    OLD.title != NEW.title OR
-    OLD.description != NEW.description OR
-    OLD.content_id != NEW.content_id OR
-    OLD.status != NEW.status OR
-    OLD.year != NEW.year OR
-    OLD.semester != NEW.semester OR
-    OLD.owner != NEW.owner OR
-    OLD.should_extend != NEW.should_extend
-BEGIN
-    UPDATE sig
-    SET updated_at = CURRENT_TIMESTAMP
-    WHERE id = OLD.id;
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON sig 
+BEGIN 
+    UPDATE sig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
 
 CREATE TRIGGER update_pig_updated_at
-AFTER UPDATE ON pig
-FOR EACH ROW
-WHEN 
-    OLD.title != NEW.title OR
-    OLD.description != NEW.description OR
-    OLD.content_id != NEW.content_id OR
-    OLD.status != NEW.status OR
-    OLD.year != NEW.year OR
-    OLD.semester != NEW.semester OR
-    OLD.owner != NEW.owner OR
-    OLD.should_extend != NEW.should_extend
-BEGIN
-    UPDATE pig
-    SET updated_at = CURRENT_TIMESTAMP
-    WHERE id = OLD.id;
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON pig 
+BEGIN 
+    UPDATE pig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
 
 ```
@@ -132,6 +111,7 @@ END;
   "title": "AI SIG",
   "description": "인공지능을 연구하는 소모임입니다.",
   "content": "## 안녕하세요",
+  "is_rolling_admission":false,
 }
 ```
 
@@ -148,7 +128,8 @@ END;
   "semester": 1,
   "created_at": "2025-03-01T10:00:00Z",
   "updated_at": "2025-04-01T12:00:00Z",
-  "owner": "hash_of_owner_user"
+  "owner": "hash_of_owner_user",
+  "is_rolling_admission":false,
 }
 ```
 
@@ -232,6 +213,7 @@ END;
   "description": "업데이트된 설명입니다.",
   "content": "### 안녕하세요",
   "should_extend": true,
+  "is_rolling_admission":true,
 }
 ```
 
@@ -297,6 +279,8 @@ END;
   "description": "업데이트된 설명입니다.",
   "content": "### 안녕하세요",
   "status": "recruiting",
+  "should_extend": true,
+  "is_rolling_admission":true,
 }
 ```
 

--- a/script/init_db/insert_tables.sh
+++ b/script/init_db/insert_tables.sh
@@ -122,6 +122,7 @@ CREATE TABLE sig (
     semester INTEGER NOT NULL CHECK (semester IN (1, 2, 3, 4)),
 
     should_extend BOOLEAN NOT NULL DEFAULT FALSE,
+    is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE,
 
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -141,6 +142,7 @@ CREATE TABLE pig (
     semester INTEGER NOT NULL CHECK (semester IN (1, 2, 3, 4)),
 
     should_extend BOOLEAN NOT NULL DEFAULT FALSE,
+    is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE,
 
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -178,6 +180,8 @@ CREATE TABLE pig_member (
 -- Create index for SIG/PIG
 CREATE INDEX idx_sig_owner ON sig(owner);
 CREATE INDEX idx_sig_term ON sig(year, semester);
+CREATE INDEX idx_pig_owner ON pig(owner);
+CREATE INDEX idx_pig_term ON pig(year, semester);
 CREATE INDEX idx_sig_member_user ON sig_member(user_id);
 CREATE INDEX idx_sig_member_ig ON sig_member(ig_id);
 CREATE INDEX idx_pig_member_user ON pig_member(user_id);
@@ -185,39 +189,15 @@ CREATE INDEX idx_pig_member_ig ON pig_member(ig_id);
 
 -- Create trigger for SIG/PIG
 CREATE TRIGGER update_sig_updated_at
-AFTER UPDATE ON sig
-FOR EACH ROW
-WHEN 
-    OLD.title != NEW.title OR
-    OLD.description != NEW.description OR
-    OLD.content_id != NEW.content_id OR
-    OLD.status != NEW.status OR
-    OLD.year != NEW.year OR
-    OLD.semester != NEW.semester OR
-    OLD.owner != NEW.owner OR
-    OLD.should_extend != NEW.should_extend
-BEGIN
-    UPDATE sig
-    SET updated_at = CURRENT_TIMESTAMP
-    WHERE id = OLD.id;
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON sig 
+BEGIN 
+    UPDATE sig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
 
 CREATE TRIGGER update_pig_updated_at
-AFTER UPDATE ON pig
-FOR EACH ROW
-WHEN 
-    OLD.title != NEW.title OR
-    OLD.description != NEW.description OR
-    OLD.content_id != NEW.content_id OR
-    OLD.status != NEW.status OR
-    OLD.year != NEW.year OR
-    OLD.semester != NEW.semester OR
-    OLD.owner != NEW.owner OR
-    OLD.should_extend != NEW.should_extend
-BEGIN
-    UPDATE pig
-    SET updated_at = CURRENT_TIMESTAMP
-    WHERE id = OLD.id;
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON pig 
+BEGIN 
+    UPDATE pig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
 
 -- SCSC global status

--- a/script/migrations/2.sql
+++ b/script/migrations/2.sql
@@ -1,9 +1,7 @@
 ALTER TABLE sig ADD COLUMN should_extend BOOLEAN NOT NULL DEFAULT 0;
 ALTER TABLE pig ADD COLUMN should_extend BOOLEAN NOT NULL DEFAULT 0;
-ALTER TABLE sig ALTER COLUMN content_id SET NOT NULL;
-ALTER TABLE pig ALTER COLUMN content_id SET NOT NULL;
 
-DROP TRIGGER IF EXISTS update_sig_updated_at ON sig;
+DROP TRIGGER IF EXISTS update_sig_updated_at;
 CREATE TRIGGER update_sig_updated_at
 AFTER UPDATE ON sig
 FOR EACH ROW
@@ -22,7 +20,7 @@ BEGIN
     WHERE id = OLD.id;
 END;
 
-DROP TRIGGER IF EXISTS update_pig_updated_at ON pig;
+DROP TRIGGER IF EXISTS update_pig_updated_at;
 CREATE TRIGGER update_pig_updated_at
 AFTER UPDATE ON pig
 FOR EACH ROW

--- a/script/migrations/3.sql
+++ b/script/migrations/3.sql
@@ -1,12 +1,13 @@
 ALTER TABLE sig ADD COLUMN is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE pig ADD COLUMN is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE;
 
-CREATE INDEX idx_pig_owner ON pig(owner);
-CREATE INDEX idx_pig_term ON pig(year, semester);
+CREATE INDEX IF NOT EXISTS idx_pig_owner ON pig(owner);
+CREATE INDEX IF NOT EXISTS idx_pig_term ON pig(year, semester);
 
 DROP TRIGGER IF EXISTS update_sig_updated_at;
 CREATE TRIGGER update_sig_updated_at
 AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON sig 
+FOR EACH ROW
 BEGIN 
     UPDATE sig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;
@@ -15,6 +16,7 @@ END;
 DROP TRIGGER IF EXISTS update_pig_updated_at; 
 CREATE TRIGGER update_pig_updated_at
 AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON pig 
+FOR EACH ROW
 BEGIN 
     UPDATE pig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
 END;

--- a/script/migrations/3.sql
+++ b/script/migrations/3.sql
@@ -1,0 +1,20 @@
+ALTER TABLE sig ADD COLUMN is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE pig ADD COLUMN is_rolling_admission BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_pig_owner ON pig(owner);
+CREATE INDEX idx_pig_term ON pig(year, semester);
+
+DROP TRIGGER IF EXISTS update_sig_updated_at;
+CREATE TRIGGER update_sig_updated_at
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON sig 
+BEGIN 
+    UPDATE sig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
+END;
+
+
+DROP TRIGGER IF EXISTS update_pig_updated_at; 
+CREATE TRIGGER update_pig_updated_at
+AFTER UPDATE OF title, description, content_id, status, year, semester, owner, should_extend, is_rolling_admission ON pig 
+BEGIN 
+    UPDATE pig SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; 
+END;

--- a/src/controller/pig.py
+++ b/src/controller/pig.py
@@ -7,17 +7,19 @@ from sqlalchemy.exc import IntegrityError
 
 from src.db import SessionDep
 from src.model import PIG, SCSCGlobalStatus, PIGMember, SCSCStatus
-from src.util import get_user_role_level, send_discord_bot_request_no_reply, send_discord_bot_request
+from src.util import get_user_role_level, send_discord_bot_request_no_reply
 
 from .article import BodyCreateArticle, create_article_ctrl
 from .scsc import ctrl_status_available
 
 logger = logging.getLogger("app")
 
+
 class BodyCreatePIG(BaseModel):
     title: str
     description: str
     content: str
+    is_rolling_admission: bool
 
 
 async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> PIG:
@@ -38,6 +40,7 @@ async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str
         semester=scsc_global_status.semester,
         owner=user_id,
         status=scsc_global_status.status,
+        is_rolling_admission=body.is_rolling_admission,
     )
     session.add(pig)
     try: session.commit()
@@ -56,7 +59,7 @@ async def create_pig_ctrl(session: SessionDep, body: BodyCreatePIG, user_id: str
     session.commit()
     session.refresh(pig)
     if user_discord_id: await send_discord_bot_request_no_reply(action_code=4003, body={'pig_name': body.title, 'user_id_list': [user_discord_id], "pig_description": pig.description})
-    logger.info(f'info_type=pig_created ; pig_id={pig.id} ; title={body.title} ; owner_id={user_id} ; year={pig.year} ; semester={pig.semester}')
+    logger.info(f'info_type=pig_created ; pig_id={pig.id} ; title={body.title} ; owner_id={user_id} ; year={pig.year} ; semester={pig.semester} ; is_rolling_admission={body.is_rolling_admission}')
     return pig
 
 
@@ -66,6 +69,7 @@ class BodyUpdatePIG(BaseModel):
     content: Optional[str] = None
     status: Optional[SCSCStatus] = None
     should_extend: Optional[bool] = None
+    is_rolling_admission: Optional[bool] = None
 
 
 async def update_pig_ctrl(session: SessionDep, id: int, body: BodyUpdatePIG, user_id: str, is_executive: bool) -> None:
@@ -87,6 +91,7 @@ async def update_pig_ctrl(session: SessionDep, id: int, body: BodyUpdatePIG, use
         if not is_executive: raise HTTPException(403, detail="관리자 이상의 권한이 필요합니다")
         pig.status = body.status
     if body.should_extend is not None: pig.should_extend = body.should_extend
+    if body.is_rolling_admission is not None: pig.is_rolling_admission = body.is_rolling_admission
 
     session.add(pig)
     try: session.commit()
@@ -94,12 +99,12 @@ async def update_pig_ctrl(session: SessionDep, id: int, body: BodyUpdatePIG, use
         session.rollback()
         raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(pig)
-    
+
     bot_body = {}
     bot_body['pig_name'] = old_title
     if body.title: bot_body['new_pig_name'] = body.title
     if body.description: bot_body['new_topic'] = body.description
     await send_discord_bot_request_no_reply(action_code=4006, body=bot_body)
-    
-    logger.info(f'info_type=pig_updated ; pig_id={id} ; title={pig.title} ; revisioner_id={user_id} ; year={pig.year} ; semester={pig.semester}')
+
+    logger.info(f'info_type=pig_updated ; pig_id={id} ; title={pig.title} ; revisioner_id={user_id} ; year={pig.year} ; semester={pig.semester} ; is_rolling_admission={body.is_rolling_admission}')
     return

--- a/src/controller/scsc.py
+++ b/src/controller/scsc.py
@@ -26,8 +26,8 @@ _valid_scsc_global_status_update = (
 @dataclass
 class _CtrlStatusAvailable:
     create_sigpig: tuple[SCSCStatus, SCSCStatus]
-    join_sigpig: tuple[SCSCStatus, SCSCStatus]
-    join_sigpig_rolling_admission: tuple[SCSCStatus, SCSCStatus, SCSCStatus]
+    join_sigpig: tuple[SCSCStatus, SCSCStatus]  # also applied to leave
+    join_sigpig_rolling_admission: tuple[SCSCStatus, SCSCStatus, SCSCStatus]  # also applied to leave
 
 
 ctrl_status_available = _CtrlStatusAvailable(

--- a/src/controller/scsc.py
+++ b/src/controller/scsc.py
@@ -27,11 +27,13 @@ _valid_scsc_global_status_update = (
 class _CtrlStatusAvailable:
     create_sigpig: tuple[SCSCStatus, SCSCStatus]
     join_sigpig: tuple[SCSCStatus, SCSCStatus]
+    join_sigpig_rolling_admission: tuple[SCSCStatus, SCSCStatus, SCSCStatus]
 
 
 ctrl_status_available = _CtrlStatusAvailable(
     create_sigpig=(SCSCStatus.surveying, SCSCStatus.recruiting),
-    join_sigpig=(SCSCStatus.surveying, SCSCStatus.recruiting)
+    join_sigpig=(SCSCStatus.surveying, SCSCStatus.recruiting),
+    join_sigpig_rolling_admission=(SCSCStatus.surveying, SCSCStatus.recruiting, SCSCStatus.active),
 )
 
 

--- a/src/controller/sig.py
+++ b/src/controller/sig.py
@@ -19,7 +19,7 @@ class BodyCreateSIG(BaseModel):
     title: str
     description: str
     content: str
-    is_rolling_admission: bool
+    is_rolling_admission: bool = False
 
 
 async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> SIG:
@@ -43,7 +43,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
         is_rolling_admission=body.is_rolling_admission,
     )
     session.add(sig)
-    try: session.commit()
+    try: session.flush()
     except IntegrityError:
         session.rollback()
         raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
@@ -56,10 +56,13 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
         status=sig.status
     )
     session.add(sig_member)
-    session.commit()
+    try: session.commit()
+    except IntegrityError:
+        session.rollback()
+        raise HTTPException(409, detail="시그장 자동 가입 중 중복 오류가 발생했습니다")
     session.refresh(sig)
-    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': [user_discord_id], "sig_description": sig.description})
-    logger.info(f'info_type=sig_created ; sig_id={sig.id} ; title={body.title} ; owner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={body.is_rolling_admission}')
+    if user_discord_id: await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': sig.title, 'user_id_list': [user_discord_id], "sig_description": sig.description})
+    logger.info(f'info_type=sig_created ; sig_id={sig.id} ; title={sig.title} ; owner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={sig.is_rolling_admission}')
     return sig
 
 
@@ -104,7 +107,7 @@ async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, use
     bot_body['sig_name'] = old_title
     if body.title: bot_body['new_sig_name'] = body.title
     if body.description: bot_body['new_topic'] = body.description
-    await send_discord_bot_request_no_reply(action_code=4005, body=bot_body)
+    if len(bot_body) > 1: await send_discord_bot_request_no_reply(action_code=4005, body=bot_body)
 
-    logger.info(f'info_type=sig_updated ; sig_id={id} ; title={sig.title} ; revisioner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={body.is_rolling_admission}')
+    logger.info(f'info_type=sig_updated ; sig_id={id} ; title={sig.title} ; revisioner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={sig.is_rolling_admission}')
     return

--- a/src/controller/sig.py
+++ b/src/controller/sig.py
@@ -7,17 +7,19 @@ from sqlalchemy.exc import IntegrityError
 
 from src.db import SessionDep
 from src.model import SIG, SCSCGlobalStatus, SIGMember, SCSCStatus
-from src.util import get_user_role_level, send_discord_bot_request_no_reply, send_discord_bot_request
+from src.util import get_user_role_level, send_discord_bot_request_no_reply
 
 from .article import BodyCreateArticle, create_article_ctrl
 from .scsc import ctrl_status_available
 
 logger = logging.getLogger("app")
 
+
 class BodyCreateSIG(BaseModel):
     title: str
     description: str
     content: str
+    is_rolling_admission: bool
 
 
 async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str, user_discord_id: Optional[int], scsc_global_status: SCSCGlobalStatus) -> SIG:
@@ -38,6 +40,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
         semester=scsc_global_status.semester,
         owner=user_id,
         status=scsc_global_status.status,
+        is_rolling_admission=body.is_rolling_admission,
     )
     session.add(sig)
     try: session.commit()
@@ -56,7 +59,7 @@ async def create_sig_ctrl(session: SessionDep, body: BodyCreateSIG, user_id: str
     session.commit()
     session.refresh(sig)
     if user_discord_id: await send_discord_bot_request_no_reply(action_code=4001, body={'sig_name': body.title, 'user_id_list': [user_discord_id], "sig_description": sig.description})
-    logger.info(f'info_type=sig_created ; sig_id={sig.id} ; title={body.title} ; owner_id={user_id} ; year={sig.year} ; semester={sig.semester}')
+    logger.info(f'info_type=sig_created ; sig_id={sig.id} ; title={body.title} ; owner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={body.is_rolling_admission}')
     return sig
 
 
@@ -66,6 +69,7 @@ class BodyUpdateSIG(BaseModel):
     content: Optional[str] = None
     status: Optional[SCSCStatus] = None
     should_extend: Optional[bool] = None
+    is_rolling_admission: Optional[bool] = None
 
 
 async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, user_id: str, is_executive: bool) -> None:
@@ -87,6 +91,7 @@ async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, use
         if not is_executive: raise HTTPException(403, detail="관리자 이상의 권한이 필요합니다")
         sig.status = body.status
     if body.should_extend is not None: sig.should_extend = body.should_extend
+    if body.is_rolling_admission is not None: sig.is_rolling_admission = body.is_rolling_admission
 
     session.add(sig)
     try: session.commit()
@@ -94,12 +99,12 @@ async def update_sig_ctrl(session: SessionDep, id: int, body: BodyUpdateSIG, use
         session.rollback()
         raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
     session.refresh(sig)
-    
+
     bot_body = {}
     bot_body['sig_name'] = old_title
     if body.title: bot_body['new_sig_name'] = body.title
     if body.description: bot_body['new_topic'] = body.description
     await send_discord_bot_request_no_reply(action_code=4005, body=bot_body)
-    
-    logger.info(f'info_type=sig_updated ; sig_id={id} ; title={sig.title} ; revisioner_id={user_id} ; year={sig.year} ; semester={sig.semester}')
+
+    logger.info(f'info_type=sig_updated ; sig_id={id} ; title={sig.title} ; revisioner_id={user_id} ; year={sig.year} ; semester={sig.semester} ; is_rolling_admission={body.is_rolling_admission}')
     return

--- a/src/model/pig.py
+++ b/src/model/pig.py
@@ -23,8 +23,9 @@ class PIG(SQLModel, table=True):
 
     year: int = Field(nullable=False)
     semester: int = Field(nullable=False)
-    
+
     should_extend: bool = Field(default=False, nullable=False)
+    is_rolling_admission: bool = Field(default=False, nullable=False)
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/model/sig.py
+++ b/src/model/sig.py
@@ -23,8 +23,9 @@ class SIG(SQLModel, table=True):
 
     year: int = Field(nullable=False)
     semester: int = Field(nullable=False)
-    
+
     should_extend: bool = Field(default=False, nullable=False)
+    is_rolling_admission: bool = Field(default=False, nullable=False)
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -52,8 +52,7 @@ async def delete_my_pig(id: int, session: SessionDep, request: Request) -> None:
     session.refresh(pig)
     year = pig.year
     semester = pig.semester
-    await send_discord_bot_request_no_reply(action_code=4004, body={'pig_name': pig.title,
-                                                                    "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
+    await send_discord_bot_request_no_reply(action_code=4004, body={'pig_name': pig.title, "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
     logger.info(f'info_type=pig_deleted ; pig_id={pig.id} ; title={pig.title} ; remover_id={current_user.id} ; year={pig.year} ; semester={pig.semester}')
     return
 
@@ -75,8 +74,7 @@ async def delete_pig(id: int, session: SessionDep, request: Request) -> None:
     session.refresh(pig)
     year = pig.year
     semester = pig.semester
-    await send_discord_bot_request_no_reply(action_code=4004, body={'pig_name': pig.title,
-                                                                    "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
+    await send_discord_bot_request_no_reply(action_code=4004, body={'pig_name': pig.title, "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
     logger.info(f'info_type=pig_deleted ; pig_id={pig.id} ; title={pig.title} ; remover_id={current_user.id} ; year={pig.year} ; semester={pig.semester}')
     return
 
@@ -118,7 +116,10 @@ async def join_pig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
+    if pig.is_rolling_admission:
+        if pig.status not in ctrl_status_available.join_sigpig_rolling_admission: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig_rolling_admission}일 때만 시그/피그에 가입할 수 있습니다")
+    else:
+        if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
     pig_member = PIGMember(
         ig_id=id,
         user_id=current_user.id,

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -118,6 +118,7 @@ async def join_pig(id: int, session: SessionDep, request: Request):
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
     allowed = (ctrl_status_available.join_sigpig_rolling_admission if pig.is_rolling_admission else ctrl_status_available.join_sigpig)
     if pig.status not in allowed: raise HTTPException(400, f"시그/피그 상태가 {allowed}일 때만 시그/피그에 가입할 수 있습니다")
+
     pig_member = PIGMember(
         ig_id=id,
         user_id=current_user.id,
@@ -139,7 +140,10 @@ async def leave_pig(id: int, session: SessionDep, scsc_global_status: SCSCGlobal
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
+    allowed = (ctrl_status_available.join_sigpig_rolling_admission if pig.is_rolling_admission else ctrl_status_available.join_sigpig)
+    if pig.status not in allowed: raise HTTPException(400, f"시그/피그 상태가 {allowed}일 때만 시그/피그에서 탈퇴할 수 있습니다")
     if pig.owner == current_user.id: raise HTTPException(409, detail="시그/피그장은 해당 시그/피그를 탈퇴할 수 없습니다")
+
     pig_member = session.exec(select(PIGMember).where(PIGMember.ig_id == id).where(PIGMember.user_id == current_user.id).where(PIGMember.status == scsc_global_status.status)).first()
     if not pig_member: raise HTTPException(404, detail="시그/피그의 구성원이 아닙니다")
     session.delete(pig_member)

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -116,10 +116,8 @@ async def join_pig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     pig = session.get(PIG, id)
     if not pig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if pig.is_rolling_admission:
-        if pig.status not in ctrl_status_available.join_sigpig_rolling_admission: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig_rolling_admission}일 때만 시그/피그에 가입할 수 있습니다")
-    else:
-        if pig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
+    allowed = (ctrl_status_available.join_sigpig_rolling_admission if pig.is_rolling_admission else ctrl_status_available.join_sigpig)
+    if pig.status not in allowed: raise HTTPException(400, f"시그/피그 상태가 {allowed}일 때만 시그/피그에 가입할 수 있습니다")
     pig_member = PIGMember(
         ig_id=id,
         user_id=current_user.id,

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -116,10 +116,9 @@ async def join_sig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if sig.is_rolling_admission:
-        if sig.status not in ctrl_status_available.join_sigpig_rolling_admission: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig_rolling_admission}일 때만 시그/피그에 가입할 수 있습니다")
-    else:
-        if sig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
+    allowed = (ctrl_status_available.join_sigpig_rolling_admission if sig.is_rolling_admission else ctrl_status_available.join_sigpig)
+    if sig.status not in allowed: raise HTTPException(400, f"시그/피그 상태가 {allowed}일 때만 시그/피그에 가입할 수 있습니다")
+
     sig_member = SIGMember(
         ig_id=id,
         user_id=current_user.id,

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -52,8 +52,7 @@ async def delete_my_sig(id: int, session: SessionDep, request: Request) -> None:
     session.refresh(sig)
     year = sig.year
     semester = sig.semester
-    await send_discord_bot_request_no_reply(action_code=4002, body={'sig_name': sig.title,
-                                                                    "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
+    await send_discord_bot_request_no_reply(action_code=4002, body={'sig_name': sig.title, "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
     logger.info(f'info_type=sig_deleted ; sig_id={sig.id} ; title={sig.title} ; remover_id={current_user.id} ; year={sig.year} ; semester={sig.semester}')
     return
 
@@ -75,8 +74,7 @@ async def delete_sig(id: int, session: SessionDep, request: Request) -> None:
     session.refresh(sig)
     year = sig.year
     semester = sig.semester
-    await send_discord_bot_request_no_reply(action_code=4002, body={'sig_name': sig.title,
-                                                                    "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
+    await send_discord_bot_request_no_reply(action_code=4002, body={'sig_name': sig.title, "previous_semester": f"{year}-{map_semester_name.get(semester)}"})
     logger.info(f'info_type=sig_deleted ; sig_id={sig.id} ; title={sig.title} ; remover_id={current_user.id} ; year={sig.year} ; semester={sig.semester}')
     return
 
@@ -118,7 +116,10 @@ async def join_sig(id: int, session: SessionDep, request: Request):
     current_user = get_user(request)
     sig = session.get(SIG, id)
     if not sig: raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
-    if sig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"SCSC 전역 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
+    if sig.is_rolling_admission:
+        if sig.status not in ctrl_status_available.join_sigpig_rolling_admission: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig_rolling_admission}일 때만 시그/피그에 가입할 수 있습니다")
+    else:
+        if sig.status not in ctrl_status_available.join_sigpig: raise HTTPException(400, f"시그/피그 상태가 {ctrl_status_available.join_sigpig}일 때만 시그/피그에 가입할 수 있습니다")
     sig_member = SIGMember(
         ig_id=id,
         user_id=current_user.id,


### PR DESCRIPTION
resolve #96 

- 시그/피그 생성/수정 시 is_rolling_admission 값 설정 가능
- 이 값이 true이면 시그/피그 상태가 active일 때도 가입 가능
- 기존에 시그/피그 가입에만 적용되었던 status 조건을 탈퇴에도 동일하게 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rolling-admission flag for SIGs and PIGs; included in create/update flows and API responses.
  - Join/leave rules now adapt when rolling admission is enabled, permitting joins/leaves in additional statuses and updating validations and notifications.

- **Documentation**
  - API docs, examples, and JSON payloads updated to include rolling admission; revision date refreshed.

- **Chores**
  - Schema migrations, new indexes, and refined updated_at trigger behavior to improve performance and update tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->