### PR TITLE
✨ 로그인 안해도 SIG, PIG 목록 볼 수 있게

### DIFF
--- a/src/routes/article.py
+++ b/src/routes/article.py
@@ -34,13 +34,11 @@ async def create_article(session: SessionDep, request: Request, body: BodyCreate
 
 
 # This works as "api/article" + "s/{board_id}" (="api/articles/{board_id}")
-@article_general_router.get('s/{board_id}')
-async def get_article_list_by_board(board_id: int, session: SessionDep, request: Request) -> list[ArticleResponse]:
+@article_general_router.get('/s/{board_id}')
+async def get_article_list_by_board(board_id: int, session: SessionDep) -> list[ArticleResponse]:
     board = session.get(Board, board_id)
     if not board: raise HTTPException(404, detail="Board not found")
 
-    current_user = get_user(request)
-    if current_user.role < board.reading_permission_level: raise HTTPException(403, detail="You are not allowed to read this board")
 
     articles = session.exec(select(Article).where(Article.board_id == board_id)).all()
     result: list[ArticleResponse] = []
@@ -59,13 +57,13 @@ async def get_article_list_by_board(board_id: int, session: SessionDep, request:
 
 
 @article_general_router.get('/{id}')
-async def get_article_by_id(id: int, session: SessionDep, request: Request) -> ArticleResponse:
+async def get_article_by_id(id: int, session: SessionDep) -> ArticleResponse:
     article = session.get(Article, id)
     if not article: raise HTTPException(404, detail="Article not found")
     board = session.get(Board, article.board_id)
     if not board: raise HTTPException(503, detail="board does not exist")
-    current_user = get_user(request)
-    if current_user.role < board.reading_permission_level: raise HTTPException(403, detail="You are not allowed to read this article")
+    
+    
     if article.is_deleted: return ArticleResponse(**article.model_dump(), content=DELETED)
 
     try:


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->
### What feature does this PR add?
<!-- Describe the feature or enhancement you implemented -->
로그인 없이도 게시글을 읽을 수 있도록 공개 읽기 기능을 추가했습니다. 사용자는 인증 없이 게시글 목록과 개별 게시글을 볼 수 있으며, 작성/수정/삭제 등의 쓰기 작업은 여전히 인증이 필요합니다.

---
### Are there any caveats or things to watch out for?
<!-- If none, write "None" -->
- **모든 게시판이 공개됨**: 현재 모든 게시판이 인증 없이 읽기 가능하므로, 민감한 내용이 있다면 노출될 수 있음
- **정보 노출 가능성**: 익명 사용자가 HTTP 응답 코드를 통해 존재하는/하지 않는 게시판을 구분할 수 있음
- **Rate limiting 없음**: 공개 엔드포인트에 과도한 요청이나 크롤링에 대한 보호 장치가 없음
- **향후 게시판별 공개/비공개 설정 기능 추가 고려** 필요 (선택적 공개 접근이 필요한 경우)
- **삭제된 게시글의 메타데이터**(제목, 작성자 등)는 여전히 "DELETED" 플레이스홀더와 함께 노출됨