### PR TITLE
feat: notify SIG/PIG leaders via SMS on enrollment

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -22,6 +23,10 @@ class Settings(BaseSettings):
     notice_channel_id: int
     grant_channel_id: int
     w_html_dir: str = "static/w/"
+    sms_api_url: Optional[str] = None
+    sms_api_key: Optional[str] = None
+    sms_api_secret: Optional[str] = None
+    sms_sender: Optional[str] = None
     db_name: str = "main_db"
     db_user: str
     db_password: str

--- a/src/services/join_notification.py
+++ b/src/services/join_notification.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Optional
+
+from src.core import logger
+from src.model import User
+from src.repositories.user import UserRepository
+from src.util import utcnow
+
+from .sms import send_sms
+
+
+async def notify_ig_owner_join_sms(
+    *,
+    ig_type: str,
+    ig_id: int,
+    ig_title: str,
+    owner_id: str,
+    joined_user: User,
+    applied_at: Optional[datetime],
+    user_repository: UserRepository,
+) -> None:
+    owner = user_repository.get_by_id(owner_id)
+    if owner is None:
+        logger.error(
+            f"err_type={ig_type}_join_sms ; err_code=404 ; msg=owner not found ; ig_id={ig_id} ; owner_id={owner_id} ; joined_user_id={joined_user.id}"
+        )
+        return
+
+    applied_at_text = (applied_at or utcnow()).strftime("%Y-%m-%d %H:%M:%S UTC")
+    content = (
+        f"[SCSC] {joined_user.name}({joined_user.id})님이 "
+        f"{ig_title}({ig_type.upper()})에 {applied_at_text} 가입 신청했습니다."
+    )
+
+    try:
+        await send_sms(to=owner.phone, content=content)
+        logger.info(
+            f"info_type={ig_type}_join_sms_queued ; ig_id={ig_id} ; owner_id={owner.id} ; joined_user_id={joined_user.id}"
+        )
+    except Exception as exc:
+        logger.error(
+            f"err_type={ig_type}_join_sms ; err_code=500 ; ig_id={ig_id} ; owner_id={owner.id} ; joined_user_id={joined_user.id} ; msg={exc}",
+            exc_info=True,
+        )

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -22,6 +22,7 @@ from src.util import (
 )
 
 from .article import ArticleServiceDep, BodyCreateArticle
+from .join_notification import notify_ig_owner_join_sms
 from .scsc import ctrl_status_available
 
 
@@ -356,6 +357,16 @@ class PigService:
                 action_code=2001,
                 body={"user_id": current_user.discord_id, "role_name": pig.title},
             )
+
+        await notify_ig_owner_join_sms(
+            ig_type="pig",
+            ig_id=pig.id,
+            ig_title=pig.title,
+            owner_id=pig.owner,
+            joined_user=current_user,
+            applied_at=pig_member.created_at,
+            user_repository=self.user_repository,
+        )
 
         logger.info(
             f"info_type=pig_join ; pig_id={pig.id} ; title={pig.title} ; executor_id={current_user.id} ; joined_user_id={current_user.id} ; year={pig.year} ; semester={pig.semester}"

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -15,6 +15,7 @@ from src.util import (
 )
 
 from .article import ArticleServiceDep, BodyCreateArticle
+from .join_notification import notify_ig_owner_join_sms
 from .scsc import ctrl_status_available
 
 
@@ -329,6 +330,16 @@ class SigService:
                 action_code=2001,
                 body={"user_id": current_user.discord_id, "role_name": sig.title},
             )
+
+        await notify_ig_owner_join_sms(
+            ig_type="sig",
+            ig_id=sig.id,
+            ig_title=sig.title,
+            owner_id=sig.owner,
+            joined_user=current_user,
+            applied_at=sig_member.created_at,
+            user_repository=self.user_repository,
+        )
 
         logger.info(
             f"info_type=sig_join ; sig_id={sig.id} ; title={sig.title} ; executor_id={current_user.id} ; joined_user_id={current_user.id} ; year={sig.year} ; semester={sig.semester}"

--- a/src/services/sms.py
+++ b/src/services/sms.py
@@ -1,0 +1,62 @@
+import hashlib
+import hmac
+import secrets
+from datetime import datetime, timezone
+
+import httpx
+
+from src.core import get_settings
+
+
+def _make_solapi_auth_header(api_key: str, api_secret: str) -> str:
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    salt = secrets.token_hex(16)
+    signature = hmac.new(
+        api_secret.encode("utf-8"),
+        f"{date}{salt}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return (
+        "HMAC-SHA256 "
+        f"apiKey={api_key}, "
+        f"date={date}, "
+        f"salt={salt}, "
+        f"signature={signature}"
+    )
+
+
+async def send_sms(to: str, content: str) -> None:
+    settings = get_settings()
+    if not settings.sms_api_key or not settings.sms_api_secret or not settings.sms_sender:
+        return
+
+    url = settings.sms_api_url or "https://api.solapi.com/messages/v4/send-many"
+
+    payload = {
+        "messages": [
+            {
+                "to": to,
+                "from": settings.sms_sender,
+                "text": content,
+                "type": "SMS",
+            }
+        ]
+    }
+
+    headers = {
+        "Authorization": _make_solapi_auth_header(
+            settings.sms_api_key, settings.sms_api_secret
+        ),
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(5.0, connect=2.0)) as client:
+        res = await client.post(
+            url,
+            json=payload,
+            headers=headers,
+        )
+    if res.status_code >= 400:
+        raise RuntimeError(
+            f"sms provider request failed with status={res.status_code}, body={res.text}"
+        )

--- a/tests/test_join_notification_unit.py
+++ b/tests/test_join_notification_unit.py
@@ -1,0 +1,113 @@
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("API_SECRET", "test-api-secret")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("JWT_VALID_SECONDS", "3600")
+os.environ.setdefault("NOTICE_CHANNEL_ID", "1")
+os.environ.setdefault("GRANT_CHANNEL_ID", "2")
+os.environ.setdefault("DB_USER", "test-user")
+os.environ.setdefault("DB_PASSWORD", "test-password")
+
+from src.services.join_notification import notify_ig_owner_join_sms
+
+
+class _FakeUserRepository:
+    def __init__(self, owner):
+        self._owner = owner
+
+    def get_by_id(self, _owner_id: str):
+        return self._owner
+
+
+def test_notify_ig_owner_join_sms_sends_message(monkeypatch):
+    owner = SimpleNamespace(id="owner-1", phone="01012345678")
+    joined_user = SimpleNamespace(id="join-1", name="Tester")
+    repository = _FakeUserRepository(owner)
+    calls = []
+
+    async def fake_send_sms(*, to: str, content: str):
+        calls.append({"to": to, "content": content})
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms",
+        fake_send_sms,
+    )
+
+    import asyncio
+
+    asyncio.run(
+        notify_ig_owner_join_sms(
+            ig_type="sig",
+            ig_id=1,
+            ig_title="Algo SIG",
+            owner_id="owner-1",
+            joined_user=joined_user,
+            applied_at=None,
+            user_repository=repository,
+        )
+    )
+
+    assert len(calls) == 1
+    body = calls[0]
+    assert body["to"] == "01012345678"
+    assert "Algo SIG" in body["content"]
+    assert "Tester" in body["content"]
+
+
+def test_notify_ig_owner_join_sms_ignores_missing_owner(monkeypatch):
+    repository = _FakeUserRepository(None)
+    joined_user = SimpleNamespace(id="join-1", name="Tester")
+    calls = []
+
+    async def fake_send_sms(*, to: str, content: str):
+        calls.append({"to": to, "content": content})
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms",
+        fake_send_sms,
+    )
+
+    import asyncio
+
+    asyncio.run(
+        notify_ig_owner_join_sms(
+            ig_type="pig",
+            ig_id=2,
+            ig_title="Web PIG",
+            owner_id="owner-x",
+            joined_user=joined_user,
+            applied_at=None,
+            user_repository=repository,
+        )
+    )
+
+    assert calls == []
+
+
+def test_notify_ig_owner_join_sms_swallows_send_error(monkeypatch):
+    owner = SimpleNamespace(id="owner-1", phone="01012345678")
+    joined_user = SimpleNamespace(id="join-1", name="Tester")
+    repository = _FakeUserRepository(owner)
+
+    async def failing_send_sms(*, to: str, content: str):
+        raise RuntimeError("mq down")
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms",
+        failing_send_sms,
+    )
+
+    import asyncio
+
+    asyncio.run(
+        notify_ig_owner_join_sms(
+            ig_type="sig",
+            ig_id=1,
+            ig_title="Algo SIG",
+            owner_id="owner-1",
+            joined_user=joined_user,
+            applied_at=None,
+            user_repository=repository,
+        )
+    )

--- a/tests/test_sigpig_join_notification_api.py
+++ b/tests/test_sigpig_join_notification_api.py
@@ -1,0 +1,206 @@
+from sqlalchemy import select
+
+from src.model import (
+    Article,
+    Board,
+    PIG,
+    PIGMember,
+    SCSCStatus,
+    SIG,
+    SIGMember,
+)
+from src.model.pig import RollingAdmission
+
+
+def _create_sig_for_join(db_session, *, owner_id: str, title: str = "Algo SIG") -> SIG:
+    board = Board(
+        name="SIG Board",
+        description="SIG content board",
+        writing_permission_level=0,
+        reading_permission_level=0,
+    )
+    db_session.add(board)
+    db_session.flush()
+
+    article = Article(title=f"{title} article", author_id=owner_id, board_id=board.id)
+    db_session.add(article)
+    db_session.flush()
+
+    sig = SIG(
+        title=title,
+        description="SIG description",
+        content_id=article.id,
+        status=SCSCStatus.recruiting,
+        created_year=2026,
+        created_semester=1,
+        year=2026,
+        semester=1,
+        owner=owner_id,
+        is_rolling_admission=False,
+    )
+    db_session.add(sig)
+    db_session.commit()
+    db_session.refresh(sig)
+    return sig
+
+
+def _create_pig_for_join(db_session, *, owner_id: str, title: str = "Web PIG") -> PIG:
+    board = Board(
+        name="PIG Board",
+        description="PIG content board",
+        writing_permission_level=0,
+        reading_permission_level=0,
+    )
+    db_session.add(board)
+    db_session.flush()
+
+    article = Article(title=f"{title} article", author_id=owner_id, board_id=board.id)
+    db_session.add(article)
+    db_session.flush()
+
+    pig = PIG(
+        title=title,
+        description="PIG description",
+        content_id=article.id,
+        status=SCSCStatus.recruiting,
+        created_year=2026,
+        created_semester=1,
+        year=2026,
+        semester=1,
+        owner=owner_id,
+        is_rolling_admission=RollingAdmission.DURING_RECRUITING,
+    )
+    db_session.add(pig)
+    db_session.commit()
+    db_session.refresh(pig)
+    return pig
+
+
+def test_join_sig_sends_owner_sms_notification(
+    api_client,
+    build_headers,
+    create_user,
+    db_session,
+    monkeypatch,
+):
+    """SIG 가입 시 시그장 번호로 문자 요청이 큐에 올라가는지 검증한다."""
+    owner, _ = create_user()
+    applicant, applicant_token = create_user()
+    sig = _create_sig_for_join(db_session, owner_id=owner.id)
+
+    calls = []
+
+    async def fake_send_sms(*, to: str, content: str):
+        calls.append({"to": to, "content": content})
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms", fake_send_sms
+    )
+
+    response = api_client.post(
+        f"/api/sig/{sig.id}/member/join",
+        headers=build_headers(applicant_token),
+    )
+
+    assert response.status_code == 204
+    assert len(calls) == 1
+    body = calls[0]
+    assert body["to"] == owner.phone
+    assert applicant.id in body["content"]
+    assert sig.title in body["content"]
+
+
+def test_join_pig_sends_owner_sms_notification(
+    api_client,
+    build_headers,
+    create_user,
+    db_session,
+    monkeypatch,
+):
+    """PIG 가입 시 피그장 번호로 문자 요청이 큐에 올라가는지 검증한다."""
+    owner, _ = create_user()
+    applicant, applicant_token = create_user()
+    pig = _create_pig_for_join(db_session, owner_id=owner.id)
+
+    calls = []
+
+    async def fake_send_sms(*, to: str, content: str):
+        calls.append({"to": to, "content": content})
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms", fake_send_sms
+    )
+
+    response = api_client.post(
+        f"/api/pig/{pig.id}/member/join",
+        headers=build_headers(applicant_token),
+    )
+
+    assert response.status_code == 204
+    assert len(calls) == 1
+    body = calls[0]
+    assert body["to"] == owner.phone
+    assert applicant.id in body["content"]
+    assert pig.title in body["content"]
+
+
+def test_join_sig_keeps_success_even_when_sms_send_fails(
+    api_client,
+    build_headers,
+    create_user,
+    db_session,
+    monkeypatch,
+):
+    """문자 발송 실패가 발생해도 가입 자체는 성공으로 유지되는지 확인한다."""
+    owner, _ = create_user()
+    applicant, applicant_token = create_user()
+    sig = _create_sig_for_join(db_session, owner_id=owner.id)
+
+    async def failing_send_sms(*, to: str, content: str):
+        raise RuntimeError("mq unavailable")
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms", failing_send_sms
+    )
+
+    response = api_client.post(
+        f"/api/sig/{sig.id}/member/join",
+        headers=build_headers(applicant_token),
+    )
+
+    assert response.status_code == 204
+    joined_member = db_session.scalar(
+        select(SIGMember).where(SIGMember.ig_id == sig.id, SIGMember.user_id == applicant.id)
+    )
+    assert joined_member is not None
+
+
+def test_join_pig_keeps_success_even_when_sms_send_fails(
+    api_client,
+    build_headers,
+    create_user,
+    db_session,
+    monkeypatch,
+):
+    """문자 발송 실패가 발생해도 피그 가입은 성공하는지 확인한다."""
+    owner, _ = create_user()
+    applicant, applicant_token = create_user()
+    pig = _create_pig_for_join(db_session, owner_id=owner.id)
+
+    async def failing_send_sms(*, to: str, content: str):
+        raise RuntimeError("mq unavailable")
+
+    monkeypatch.setattr(
+        "src.services.join_notification.send_sms", failing_send_sms
+    )
+
+    response = api_client.post(
+        f"/api/pig/{pig.id}/member/join",
+        headers=build_headers(applicant_token),
+    )
+
+    assert response.status_code == 204
+    joined_member = db_session.scalar(
+        select(PIGMember).where(PIGMember.ig_id == pig.id, PIGMember.user_id == applicant.id)
+    )
+    assert joined_member is not None

--- a/tests/test_sms_solapi_unit.py
+++ b/tests/test_sms_solapi_unit.py
@@ -1,0 +1,91 @@
+import os
+import re
+
+os.environ.setdefault("API_SECRET", "test-api-secret")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("JWT_VALID_SECONDS", "3600")
+os.environ.setdefault("NOTICE_CHANNEL_ID", "1")
+os.environ.setdefault("GRANT_CHANNEL_ID", "2")
+os.environ.setdefault("DB_USER", "test-user")
+os.environ.setdefault("DB_PASSWORD", "test-password")
+
+from src.core import get_settings
+from src.services.sms import send_sms
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, text="ok"):
+        self.status_code = status_code
+        self.text = text
+
+
+def test_send_sms_uses_solapi_request_shape(monkeypatch):
+    monkeypatch.setenv("SMS_API_KEY", "key-123")
+    monkeypatch.setenv("SMS_API_SECRET", "secret-123")
+    monkeypatch.setenv("SMS_SENDER", "01099998888")
+    monkeypatch.delenv("SMS_API_URL", raising=False)
+    get_settings.cache_clear()
+
+    captured = {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return _FakeResponse(200, "ok")
+
+    monkeypatch.setattr("src.services.sms.httpx.AsyncClient", _FakeAsyncClient)
+
+    import asyncio
+
+    asyncio.run(send_sms("01012345678", "hello"))
+
+    assert captured["url"] == "https://api.solapi.com/messages/v4/send-many"
+    assert captured["json"]["messages"][0]["to"] == "01012345678"
+    assert captured["json"]["messages"][0]["from"] == "01099998888"
+    assert captured["json"]["messages"][0]["text"] == "hello"
+    assert captured["json"]["messages"][0]["type"] == "SMS"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["headers"]["Authorization"].startswith("HMAC-SHA256 ")
+    assert re.search(r"apiKey=key-123", captured["headers"]["Authorization"])
+    assert re.search(r"signature=[0-9a-f]{64}", captured["headers"]["Authorization"])
+
+
+def test_send_sms_is_noop_when_not_configured(monkeypatch):
+    monkeypatch.delenv("SMS_API_KEY", raising=False)
+    monkeypatch.delenv("SMS_API_SECRET", raising=False)
+    monkeypatch.delenv("SMS_SENDER", raising=False)
+    get_settings.cache_clear()
+
+    called = {"post": False}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, *args, **kwargs):
+            called["post"] = True
+            return _FakeResponse(200, "ok")
+
+    monkeypatch.setattr("src.services.sms.httpx.AsyncClient", _FakeAsyncClient)
+
+    import asyncio
+
+    asyncio.run(send_sms("01012345678", "hello"))
+    assert called["post"] is False


### PR DESCRIPTION

<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->



## ✨ 시그원, 피그원이 가입하면 시그장한테 누가 언제 가입했는지 sms 보냄
sms 제공사로 solapi 사용.
<!-- 구현한 기능 또는 개선 사항에 대해 설명해 주세요 -->


### 주의
db 등 접근이 안돼서 테스트 제대로 안했음. 
추가된 테스트 코드 사실상 무용함.
직접 solapi 계정 만들고 연결해서 테스트 필요

<!-- 없으면 "None"을 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SMS configuration settings to enable SMS notifications.
  * Introduced SMS notifications to group owners when new members join their SIGs or PIGs, including member name, group title, and timestamp details.
  * Integrated SMS sending capability via Solapi service.

* **Tests**
  * Added comprehensive unit and integration tests for SMS functionality and join notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->