### PR TITLE
:zap: Sig, Pig Joined Model 구현

### DIFF
--- a/docs/api/sigpig.md
+++ b/docs/api/sigpig.md
@@ -107,6 +107,7 @@ END;
 - 시그 정보를 관리하는 API
 - 시그장은 사용자 테이블과 외래 키로 연결됨
 - 시그 구성원은 시그 테이블, 사용자 테이블과 외래 키로 연결됨
+- 응답 형식은 [/src/schemas/sig.py](/src/schemas/sig.py) 참고하십시오
 
 ---
 
@@ -126,27 +127,7 @@ END;
 }
 ```
 
-* **Response**:
-
-```json
-{
-  "id": 1,
-  "title": "AI SIG",
-  "description": "인공지능을 연구하는 소모임입니다.",
-  "content_id": 1,
-  "status": "recruiting",
-  "created_year": 2025,
-  "created_semester": 1,
-  "year": 2025,
-  "semester": 1,
-  "created_at": "2025-03-01T10:00:00Z",
-  "updated_at": "2025-04-01T12:00:00Z",
-  "owner": "hash_of_owner_user",
-  "is_rolling_admission": false
-}
-
-```
-
+* **Response**: `SigResponse`
 * **Status Codes**:
 
   * `201 Created`
@@ -161,27 +142,7 @@ END;
 
 * **Method**: `GET`
 * **URL**: `/api/sig/:id`
-* **Response**:
-
-```json
-{
-  "id": 1,
-  "title": "AI SIG",
-  "description": "인공지능을 연구하는 소모임입니다.",
-  "content_id": 1,
-  "status": "active",
-  "created_year": 2025,
-  "created_semester": 1,
-  "year": 2025,
-  "semester": 1,
-  "created_at": "2025-03-01T10:00:00Z",
-  "updated_at": "2025-04-01T12:00:00Z",
-  "owner": "hash_of_owner_user",
-  "should_extend": true,
-  "is_rolling_admission": true,
-}
-```
-
+* **Response**: `SigResponse`
 * **Status Codes**:
 
   * `200 OK`
@@ -199,33 +160,8 @@ END;
   * `status` `str`
 * **Example Request**:
   * `/api/sigs?year=2025&semester=3&status=active`
-* **Response**:
-
-```json
-[
-  {
-    "id": 1,
-    "title": "AI SIG",
-    "description": "인공지능을 연구하는 소모임입니다.",
-    "content_id": 1,
-    "status": "active",
-    "created_year": 2025,
-    "created_semester": 1,
-    "year": 2025,
-    "semester": 1,
-    "created_at": "2025-03-01T10:00:00Z",
-    "updated_at": "2025-04-01T12:00:00Z",
-    "owner": "hash_of_owner_user",
-    "should_extend": true,
-    "is_rolling_admission": true,
-  },
-  ...
-]
-
-```
-
+* **Response**: `Sequence[SigResponse]`
 * **Status Codes**:
-
   * `200 OK`
 
 ---
@@ -573,6 +509,7 @@ END;
 * 시그와 구조가 다른 피그만의 API 예외 사항은 아래와 같다.
 * 피그는 `is_rolling_admission` 이 Boolean 이 아니라 String 타입이며 `always`, `never`, `during_recruiting`의 세 가지 경우가 존재한다.
 * 피그는 웹사이트(string)을 여러 개 가질 수 있다. 
+* 응답 형식은 [/src/schemas/pig.py](/src/schemas/pig.py) 참고하십시오
 
 ---
 
@@ -599,40 +536,8 @@ END;
 }
 ```
 
-* **Response**:
-
-```json
-{
-  "id": 1,
-  "title": "AI PIG",
-  "description": "인공지능을 연구하는 소모임입니다.",
-  "content_id": 1,
-  "status": "active",
-  "created_year": 2025,
-  "created_semester": 1,
-  "year": 2025,
-  "semester": 1,
-  "owner": "hash_of_owner_user",
-  "should_extend": true,
-  "is_rolling_admission": "during_recruiting",
-  "created_at": "2025-03-01T10:00:00Z",
-  "updated_at": "2025-04-01T12:00:00Z",
-  "websites": [
-    {
-      "id": 101,
-      "pig_id": 1,
-      "label": "GitHub",
-      "url": "https://github.com/aipig",
-      "sort_order": 1,
-      "created_at": "2025-03-01T10:00:00Z",
-      "updated_at": "2025-03-01T10:00:00Z"
-    }
-  ]
-}
-```
-
+* **Response**: `PigResponse`
 * **Status Codes**:
-
   * `201 Created`
   * `400 Bad Request`: pig global status가 recruiting이 아닐 때
   * `401 Unauthorized`: 로그인 하지 않음
@@ -645,40 +550,8 @@ END;
 
 * **Method**: `GET`
 * **URL**: `/api/pig/:id`
-* **Response**:
-
-```json
-{
-  "id": 1,
-  "title": "AI PIG",
-  "description": "인공지능을 연구하는 소모임입니다.",
-  "content_id": 1,
-  "status": "active",
-  "created_year": 2025,
-  "created_semester": 1,
-  "year": 2025,
-  "semester": 1,
-  "owner": "hash_of_owner_user",
-  "should_extend": true,
-  "is_rolling_admission": "during_recruiting",
-  "created_at": "2025-03-01T10:00:00Z",
-  "updated_at": "2025-04-01T12:00:00Z",
-  "websites": [
-    {
-      "id": 101,
-      "pig_id": 1,
-      "label": "GitHub",
-      "url": "https://github.com/aipig",
-      "sort_order": 1,
-      "created_at": "2025-03-01T10:00:00Z",
-      "updated_at": "2025-03-01T10:00:00Z"
-    }
-  ]
-}
-```
-
+* **Response**: `PigResponse`
 * **Status Codes**:
-
   * `200 OK`
   * `404 Not Found`: 해당 PIG가 존재하지 않음
 
@@ -694,44 +567,8 @@ END;
   * `status` `str`
 * **Example Request**:
   * `/api/pigs?year=2025&semester=3&status=active`
-* **Response**:
-
-```json
-[
-  {
-    "id": 1,
-    "title": "AI PIG",
-    "description": "인공지능을 연구하는 소모임입니다.",
-    "content_id": 1,
-    "status": "active",
-    "created_year": 2025,
-    "created_semester": 1,
-    "year": 2025,
-    "semester": 1,
-    "owner": "hash_of_owner_user",
-    "should_extend": true,
-    "is_rolling_admission": "during_recruiting",
-    "created_at": "2025-03-01T10:00:00Z",
-    "updated_at": "2025-04-01T12:00:00Z",
-    "websites": [
-      {
-        "id": 101,
-        "pig_id": 1,
-        "label": "GitHub",
-        "url": "https://github.com/aipig",
-        "sort_order": 1,
-        "created_at": "2025-03-01T10:00:00Z",
-        "updated_at": "2025-03-01T10:00:00Z"
-      }
-    ]
-  },
-  ...
-]
-
-```
-
+* **Response**: `Sequence[PigResponse]`
 * **Status Codes**:
-
   * `200 OK`
 
 

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -9,5 +9,12 @@ from .major import Major
 from .pig import PIG, PIGMember, PIGWebsite
 from .scsc_global_status import SCSCGlobalStatus, SCSCStatus
 from .sig import SIG, SIGMember, SIGTag, Tag
-from .user import Enrollment, OldboyApplicant, StandbyReqTbl, User, UserRole
+from .user import (
+    Enrollment,
+    OldboyApplicant,
+    StandbyReqTbl,
+    User,
+    UserRole,
+    UserSummary,
+)
 from .w_html_metadata import WHTMLMetadata

--- a/src/model/pig.py
+++ b/src/model/pig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum as PythonEnum
 
@@ -11,12 +13,13 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.util import utcnow
 
 from .base import Base
 from .scsc_global_status import SCSCStatus
+from .user import UserSummary
 
 
 class RollingAdmission(str, PythonEnum):
@@ -84,6 +87,16 @@ class PIG(Base):
         onupdate=utcnow,
     )
 
+    owner_user: Mapped[UserSummary] = relationship(
+        "UserSummary", lazy="selectin", init=False, viewonly=True
+    )
+    members: Mapped[list[PIGMember]] = relationship(
+        "PIGMember", lazy="selectin", init=False, viewonly=True
+    )
+    websites: Mapped[list[PIGWebsite]] = relationship(
+        "PIGWebsite", lazy="selectin", init=False, viewonly=True
+    )
+
 
 class PIGMember(Base):
     __tablename__ = "pig_member"
@@ -97,6 +110,10 @@ class PIGMember(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=False),
         default_factory=utcnow,
+    )
+
+    user: Mapped[UserSummary] = relationship(
+        "UserSummary", lazy="selectin", init=False, viewonly=True
     )
 
 

--- a/src/model/pig.py
+++ b/src/model/pig.py
@@ -100,7 +100,9 @@ class PIG(Base):
 
 class PIGMember(Base):
     __tablename__ = "pig_member"
-    __table_args__ = (UniqueConstraint("ig_id", "user_id", name="uq_ig_user"),)
+    __table_args__ = (
+        UniqueConstraint("ig_id", "user_id", name="uq_pig_member_ig_user"),
+    )
 
     id: Mapped[int] = mapped_column(
         Integer, primary_key=True, autoincrement=True, init=False

--- a/src/model/sig.py
+++ b/src/model/sig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from sqlalchemy import (
@@ -10,12 +12,13 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.util import utcnow
 
 from .base import Base
 from .scsc_global_status import SCSCStatus
+from .user import UserSummary
 
 
 class SIG(Base):
@@ -70,6 +73,16 @@ class SIG(Base):
         onupdate=utcnow,
     )
 
+    owner_user: Mapped[UserSummary] = relationship(
+        "UserSummary", lazy="selectin", init=False, viewonly=True
+    )
+    members: Mapped[list[SIGMember]] = relationship(
+        "SIGMember", lazy="selectin", init=False, viewonly=True
+    )
+    tags: Mapped[list[Tag]] = relationship(
+        "Tag", secondary="sig_tag", lazy="selectin", init=False, viewonly=True
+    )
+
 
 class SIGMember(Base):
     __tablename__ = "sig_member"
@@ -83,6 +96,10 @@ class SIGMember(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=False),
         default_factory=utcnow,
+    )
+
+    user: Mapped[UserSummary] = relationship(
+        "UserSummary", lazy="selectin", init=False, viewonly=True
     )
 
 

--- a/src/model/sig.py
+++ b/src/model/sig.py
@@ -86,7 +86,9 @@ class SIG(Base):
 
 class SIGMember(Base):
     __tablename__ = "sig_member"
-    __table_args__ = (UniqueConstraint("ig_id", "user_id", name="uq_ig_user"),)
+    __table_args__ = (
+        UniqueConstraint("ig_id", "user_id", name="uq_sig_member_ig_user"),
+    )
 
     id: Mapped[int] = mapped_column(
         Integer, primary_key=True, autoincrement=True, init=False

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -69,7 +69,7 @@ class UserSummary(Base):
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(String)
-    role: Mapped[int] = mapped_column(Integer)
+    role: Mapped[int] = mapped_column(Integer, ForeignKey("user_role.level"))
     major_id: Mapped[int] = mapped_column(ForeignKey("major.id"))
     is_active: Mapped[bool] = mapped_column(Boolean)
     is_banned: Mapped[bool] = mapped_column(Boolean)

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.util import utcnow
 
 from .base import Base
+from .major import Major
 
 
 class UserRole(Base):
@@ -67,8 +70,13 @@ class UserSummary(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(String)
     role: Mapped[int] = mapped_column(Integer)
+    major_id: Mapped[int] = mapped_column(ForeignKey("major.id"))
     is_active: Mapped[bool] = mapped_column(Boolean)
     is_banned: Mapped[bool] = mapped_column(Boolean)
+
+    major: Mapped[Major] = relationship(
+        "Major", lazy="selectin", init=False, viewonly=True
+    )
 
 
 class StandbyReqTbl(Base):

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -64,7 +64,14 @@ class User(Base):
 
 
 class UserSummary(Base):
-    __tablename__ = "user"  # Points to the existing user table
+    """
+    A read-only projection of the 'user' table containing public profile data.
+
+    This model maps to a subset of the 'user' table to optimize queries and protect privacy.
+    It includes a pre-joined relationship to the 'Major' model.
+    """
+
+    __tablename__ = "user"
     __table_args__ = {"extend_existing": True}  # Allows multiple mappings to one table
 
     id: Mapped[str] = mapped_column(String, primary_key=True)

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -60,6 +60,17 @@ class User(Base):
     )
 
 
+class UserSummary(Base):
+    __tablename__ = "user"  # Points to the existing user table
+    __table_args__ = {"extend_existing": True}  # Allows multiple mappings to one table
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String)
+    role: Mapped[int] = mapped_column(Integer)
+    is_active: Mapped[bool] = mapped_column(Boolean)
+    is_banned: Mapped[bool] = mapped_column(Boolean)
+
+
 class StandbyReqTbl(Base):
     __tablename__ = "standby_req_tbl"
 

--- a/src/repositories/user.py
+++ b/src/repositories/user.py
@@ -4,7 +4,14 @@ from fastapi import Depends
 from sqlalchemy import delete, desc, exists, func, select
 
 from src.db import get_user_role_level
-from src.model import Enrollment, OldboyApplicant, StandbyReqTbl, User, UserRole
+from src.model import (
+    Enrollment,
+    OldboyApplicant,
+    StandbyReqTbl,
+    User,
+    UserRole,
+    UserSummary,
+)
 
 from .crud_repository import CRUDRepository
 
@@ -53,6 +60,9 @@ class UserRepository(CRUDRepository[User, str]):
         return self.session.scalars(
             select(User).where(User.role >= get_user_role_level("executive"))
         ).all()
+
+    def get_all_summary(self) -> Sequence[UserSummary]:
+        return self.session.scalars(select(UserSummary)).all()
 
     def delete_all_except_student_ids(self, excluded_student_ids: list[str]) -> None:
         if not excluded_student_ids:

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -25,13 +25,13 @@ async def create_pig(
     pig_service: PigServiceDep,
 ) -> PigResponse:
     pig = await pig_service.create_pig(scsc_global_status, current_user, body)
-    return pig_service.get_pig_response(pig)
+    return PigResponse.model_validate(pig)
 
 
 @pig_router.get("/pig/{id}")
 async def get_pig_by_id(id: int, pig_service: PigServiceDep) -> PigResponse:
     pig = pig_service.get_by_id(id)
-    return pig_service.get_pig_response(pig)
+    return PigResponse.model_validate(pig)
 
 
 @pig_router.get("/pigs")
@@ -41,10 +41,12 @@ async def get_all_pigs(
     semester: Optional[int] = None,
     status: Optional[SCSCStatus] = None,
 ) -> Sequence[PigResponse]:
-    return pig_service.get_pigs(
-        year,
-        semester,
-        status,
+    return PigResponse.model_validate_list(
+        pig_service.get_pigs(
+            year,
+            semester,
+            status,
+        )
     )
 
 
@@ -110,7 +112,7 @@ async def executive_handover_pig(
 async def get_pig_members(
     id: int, pig_service: PigServiceDep
 ) -> Sequence[PigMemberResponse]:
-    return pig_service.get_members(id)
+    return PigMemberResponse.model_validate_list(pig_service.get_members(id))
 
 
 @pig_router.post("/pig/{id}/member/join", status_code=204)

--- a/src/routes/pig.py
+++ b/src/routes/pig.py
@@ -41,13 +41,12 @@ async def get_all_pigs(
     semester: Optional[int] = None,
     status: Optional[SCSCStatus] = None,
 ) -> Sequence[PigResponse]:
-    return PigResponse.model_validate_list(
-        pig_service.get_pigs(
-            year,
-            semester,
-            status,
-        )
+    pigs = pig_service.get_pigs(
+        year,
+        semester,
+        status,
     )
+    return PigResponse.model_validate_list(pigs)
 
 
 @pig_router.post("/pig/{id}/update", status_code=204)

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -46,13 +46,12 @@ async def get_all_sigs(
     semester: Optional[int] = None,
     status: Optional[SCSCStatus] = None,
 ) -> Sequence[SigResponse]:
-    return SigResponse.model_validate_list(
-        sig_service.get_sigs(
-            year,
-            semester,
-            status,
-        )
+    sigs = sig_service.get_sigs(
+        year,
+        semester,
+        status,
     )
+    return SigResponse.model_validate_list(sigs)
 
 
 @sig_router.post("/sig/{id}/update", status_code=204)

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -36,7 +36,7 @@ async def create_sig(
 
 @sig_router.get("/sig/{id}")
 async def get_sig_by_id(id: int, sig_service: SigServiceDep) -> SigResponse:
-    return sig_service.get_sig_response_by_id(id)
+    return SigResponse.model_validate(sig_service.get_sig_response_by_id(id))
 
 
 @sig_router.get("/sigs")
@@ -46,10 +46,12 @@ async def get_all_sigs(
     semester: Optional[int] = None,
     status: Optional[SCSCStatus] = None,
 ) -> Sequence[SigResponse]:
-    return sig_service.get_sigs(
-        year,
-        semester,
-        status,
+    return SigResponse.model_validate_list(
+        sig_service.get_sigs(
+            year,
+            semester,
+            status,
+        )
     )
 
 
@@ -115,7 +117,7 @@ async def executive_handover_sig(
 async def get_sig_members(
     id: int, sig_service: SigServiceDep
 ) -> Sequence[SigMemberResponse]:
-    return sig_service.get_members(id)
+    return SigMemberResponse.model_validate_list(sig_service.get_members(id))
 
 
 @sig_router.post("/sig/{id}/member/join", status_code=204)

--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -36,7 +36,7 @@ async def create_sig(
 
 @sig_router.get("/sig/{id}")
 async def get_sig_by_id(id: int, sig_service: SigServiceDep) -> SigResponse:
-    return SigResponse.model_validate(sig_service.get_sig_response_by_id(id))
+    return SigResponse.model_validate(sig_service.get_by_id(id))
 
 
 @sig_router.get("/sigs")

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -1,8 +1,7 @@
 ﻿from typing import Optional, Sequence
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, UploadFile
 
-from src.db import get_user_role_level
 from src.dependencies import UserDep, api_secret
 from src.schemas import PublicUserResponse, UserResponse, UserSummaryResponse
 from src.services import (
@@ -86,7 +85,9 @@ async def get_user_summaries(
     current_user: UserDep,
     user_service: UserServiceDep,
 ) -> Sequence[UserSummaryResponse]:
-    return user_service.get_user_summaries(current_user)
+    return UserSummaryResponse.model_validate_list(
+        user_service.get_user_summaries(current_user)
+    )
 
 
 @user_router.get("/executive/user/{id}", response_model=UserResponse)  # noqa: A002

--- a/src/schemas/pig.py
+++ b/src/schemas/pig.py
@@ -1,11 +1,10 @@
 from datetime import datetime
-from typing import Optional
 
 from src.model import SCSCStatus
 from src.model.pig import RollingAdmission
 
 from .base import BaseResponse
-from .user import UserResponse
+from .user import UserSummaryResponse
 
 
 class PigMemberResponse(BaseResponse):
@@ -13,7 +12,7 @@ class PigMemberResponse(BaseResponse):
     ig_id: int
     user_id: str
     created_at: datetime
-    user: Optional[UserResponse] = None
+    user: UserSummaryResponse
 
 
 class PigWebsiteResponse(BaseResponse):
@@ -41,4 +40,6 @@ class PigResponse(BaseResponse):
     is_rolling_admission: RollingAdmission
     created_at: datetime
     updated_at: datetime
-    websites: list[PigWebsiteResponse] = []
+    owner_user: UserSummaryResponse
+    members: list[PigMemberResponse]
+    websites: list[PigWebsiteResponse]

--- a/src/schemas/sig.py
+++ b/src/schemas/sig.py
@@ -1,11 +1,9 @@
 from datetime import datetime
 
-from pydantic import Field
-
 from src.model import SCSCStatus
 
 from .base import BaseResponse
-from .user import UserResponse
+from .user import UserSummaryResponse
 
 
 class TagResponse(BaseResponse):
@@ -19,7 +17,7 @@ class SigMemberResponse(BaseResponse):
     ig_id: int
     user_id: str
     created_at: datetime
-    user: UserResponse | None = None
+    user: UserSummaryResponse
 
 
 class SigResponse(BaseResponse):
@@ -37,7 +35,9 @@ class SigResponse(BaseResponse):
     is_rolling_admission: bool
     created_at: datetime
     updated_at: datetime
-    tags: list[TagResponse] = Field(default_factory=list)
+    owner_user: UserSummaryResponse
+    members: list[SigMemberResponse]
+    tags: list[TagResponse]
 
 
 class SigTagResponse(BaseResponse):

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from .base import BaseResponse
+from .major import MajorResponse
 
 
 class UserResponse(BaseResponse):
@@ -30,6 +31,7 @@ class UserSummaryResponse(BaseResponse):
     role: int
     is_active: bool
     is_banned: bool
+    major: MajorResponse
 
 
 class PublicUserResponse(BaseResponse):

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -312,7 +312,7 @@ class PigService:
         """
         Throws HTTPException with status 404 when no pig corresponding to the id found
         """
-        pig = self.get_by_id(id)  # check existence of the pig
+        pig = self.get_by_id(id)
         return pig.members
 
     async def join_pig(self, id: int, current_user: User) -> None:

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -142,7 +142,7 @@ class PigService:
 
     def get_by_id(self, id: int) -> PIG:
         """
-        Throws HTTPException with status 404 when no sig corresponding to the id found
+        Throws HTTPException with status 404 when no pig corresponding to the id found
         """
         pig = self.pig_repository.get_by_id(id)
         if not pig:
@@ -310,7 +310,7 @@ class PigService:
 
     def get_members(self, id: int) -> Sequence[PIGMember]:
         """
-        Throws HTTPException with status 404 when no sig corresponding to the id found
+        Throws HTTPException with status 404 when no pig corresponding to the id found
         """
         pig = self.get_by_id(id)  # check existence of the pig
         return pig.members

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -141,6 +141,9 @@ class PigService:
         return pig
 
     def get_by_id(self, id: int) -> PIG:
+        """
+        Throws HTTPException with status 404 when no sig corresponding to the id found
+        """
         pig = self.pig_repository.get_by_id(id)
         if not pig:
             raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
@@ -306,8 +309,11 @@ class PigService:
         self._handover_pig_ctrl(pig, body.new_owner, current_user.id, is_executive)
 
     def get_members(self, id: int) -> Sequence[PIGMember]:
-        self.get_by_id(id)
-        return self.pig_member_repository.get_members_by_pig_id(id)
+        """
+        Throws HTTPException with status 404 when no sig corresponding to the id found
+        """
+        pig = self.get_by_id(id)  # check existence of the pig
+        return pig.members
 
     async def join_pig(self, id: int, current_user: User) -> None:
         pig = self.get_by_id(id)

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -15,7 +15,6 @@ from src.repositories import (
     PigWebsiteRepositoryDep,
     UserRepositoryDep,
 )
-from src.schemas import PigMemberResponse, PigResponse, PigWebsiteResponse, UserResponse
 from src.util import (
     map_semester_name,
 )
@@ -152,7 +151,7 @@ class PigService:
         year: Optional[int] = None,
         semester: Optional[int] = None,
         status: Optional[SCSCStatus] = None,
-    ) -> Sequence[PigResponse]:
+    ) -> Sequence[PIG]:
         filters = {}
         if year is not None:
             filters["year"] = year
@@ -161,8 +160,7 @@ class PigService:
         if status:
             filters["status"] = status
 
-        pigs = self.pig_repository.get_by_filters(filters)
-        return PigResponse.model_validate_list(pigs)
+        return self.pig_repository.get_by_filters(filters)
 
     async def update_pig(
         self,
@@ -307,28 +305,9 @@ class PigService:
             raise HTTPException(403, detail="타인의 시그/피그를 변경할 수 없습니다")
         self._handover_pig_ctrl(pig, body.new_owner, current_user.id, is_executive)
 
-    def get_members(self, id: int) -> Sequence[PigMemberResponse]:
+    def get_members(self, id: int) -> Sequence[PIGMember]:
         self.get_by_id(id)
-
-        members = self.pig_member_repository.get_members_by_pig_id(id)
-        res: list[PigMemberResponse] = []
-        for member in members:
-            user = self.user_repository.get_by_id(member.user_id)
-
-            user_response = None
-            if user:
-                user_response = UserResponse.model_validate(user)
-
-            member_response = PigMemberResponse(
-                id=member.id,
-                ig_id=member.ig_id,
-                user_id=member.user_id,
-                created_at=member.created_at,
-                user=user_response,
-            )
-            res.append(member_response)
-
-        return res
+        return self.pig_member_repository.get_members_by_pig_id(id)
 
     async def join_pig(self, id: int, current_user: User) -> None:
         pig = self.get_by_id(id)
@@ -456,14 +435,6 @@ class PigService:
         logger.info(
             f"info_type=pig_leave ; pig_id={pig.id} ; title={pig.title} ; executor_id={current_user.id} ; left_user_id={body.user_id} ; year={pig.year} ; semester={pig.semester}"
         )
-
-    def get_pig_response(self, pig: PIG) -> PigResponse:
-        websites = []
-        if pig.id is not None:
-            websites = self.pig_website_repository.get_by_pig_id(pig.id)
-        website_responses = PigWebsiteResponse.model_validate_list(websites)
-        pig_response = PigResponse.model_validate(pig)
-        return pig_response.model_copy(update={"websites": website_responses})
 
     def _replace_websites(
         self, pig_id: int, websites: Optional[Sequence[BodyPigWebsite]]

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -149,9 +149,6 @@ class SigService:
             raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
         return sig
 
-    def get_sig_response_by_id(self, id: int) -> SIG:
-        return self.get_by_id(id)
-
     def get_sigs(
         self,
         year: Optional[int] = None,

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -306,8 +306,8 @@ class SigService:
         self._handover_sig_ctrl(sig, body.new_owner, current_user.id, is_executive)
 
     def get_members(self, id: int) -> Sequence[SIGMember]:
-        self.get_by_id(id)  # check existence of the sig
-        return self.sig_member_repository.get_members_by_sig_id(id)
+        sig = self.get_by_id(id)  # check existence of the sig
+        return sig.members
 
     async def join_sig(self, id: int, current_user: User) -> None:
         sig = self.get_by_id(id)

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -144,6 +144,9 @@ class SigService:
         return sig
 
     def get_by_id(self, id: int) -> SIG:
+        """
+        Throws HTTPException with status 404 when no sig corresponding to the id found
+        """
         sig = self.sig_repository.get_by_id(id)
         if not sig:
             raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
@@ -306,6 +309,9 @@ class SigService:
         self._handover_sig_ctrl(sig, body.new_owner, current_user.id, is_executive)
 
     def get_members(self, id: int) -> Sequence[SIGMember]:
+        """
+        Throws HTTPException with status 404 when no sig corresponding to the id found
+        """
         sig = self.get_by_id(id)  # check existence of the sig
         return sig.members
 

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -15,7 +15,7 @@ from src.repositories import (
     TagRepositoryDep,
     UserRepositoryDep,
 )
-from src.schemas import SigMemberResponse, SigResponse, TagResponse, UserResponse
+from src.schemas import TagResponse
 from src.util import map_semester_name
 
 from .article import ArticleServiceDep, BodyCreateArticle
@@ -78,25 +78,6 @@ class SigService:
             tag_responses.append(TagResponse.model_validate(tag))
 
         return tag_responses
-
-    def _build_sig_response(self, sig: SIG) -> SigResponse:
-        return SigResponse(
-            id=sig.id,
-            title=sig.title,
-            description=sig.description,
-            content_id=sig.content_id,
-            status=sig.status,
-            created_year=sig.created_year,
-            created_semester=sig.created_semester,
-            year=sig.year,
-            semester=sig.semester,
-            owner=sig.owner,
-            should_extend=sig.should_extend,
-            is_rolling_admission=sig.is_rolling_admission,
-            created_at=sig.created_at,
-            updated_at=sig.updated_at,
-            tags=self._get_tags_for_sig(sig.id),
-        )
 
     async def create_sig(
         self,
@@ -168,16 +149,15 @@ class SigService:
             raise HTTPException(404, detail="해당 id의 시그/피그가 없습니다")
         return sig
 
-    def get_sig_response_by_id(self, id: int) -> SigResponse:
-        sig = self.get_by_id(id)
-        return self._build_sig_response(sig)
+    def get_sig_response_by_id(self, id: int) -> SIG:
+        return self.get_by_id(id)
 
     def get_sigs(
         self,
         year: Optional[int] = None,
         semester: Optional[int] = None,
         status: Optional[SCSCStatus] = None,
-    ) -> Sequence[SigResponse]:
+    ) -> Sequence[SIG]:
         filters = {}
         if year is not None:
             filters["year"] = year
@@ -186,8 +166,7 @@ class SigService:
         if status:
             filters["status"] = status
 
-        sigs = self.sig_repository.get_by_filters(filters)
-        return [self._build_sig_response(sig) for sig in sigs]
+        return self.sig_repository.get_by_filters(filters)
 
     async def update_sig(
         self,
@@ -329,28 +308,9 @@ class SigService:
             raise HTTPException(403, detail="타인의 시그/피그를 변경할 수 없습니다")
         self._handover_sig_ctrl(sig, body.new_owner, current_user.id, is_executive)
 
-    def get_members(self, id: int) -> Sequence[SigMemberResponse]:
-        self.get_by_id(id)
-
-        members = self.sig_member_repository.get_members_by_sig_id(id)
-        res: list[SigMemberResponse] = []
-        for member in members:
-            user = self.user_repository.get_by_id(member.user_id)
-
-            user_response = None
-            if user:
-                user_response = UserResponse.model_validate(user)
-
-            member_response = SigMemberResponse(
-                id=member.id,
-                ig_id=member.ig_id,
-                user_id=member.user_id,
-                created_at=member.created_at,
-                user=user_response,
-            )
-            res.append(member_response)
-
-        return res
+    def get_members(self, id: int) -> Sequence[SIGMember]:
+        self.get_by_id(id)  # check existence of the sig
+        return self.sig_member_repository.get_members_by_sig_id(id)
 
     async def join_sig(self, id: int, current_user: User) -> None:
         sig = self.get_by_id(id)

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -312,7 +312,7 @@ class SigService:
         """
         Throws HTTPException with status 404 when no sig corresponding to the id found
         """
-        sig = self.get_by_id(id)  # check existence of the sig
+        sig = self.get_by_id(id)
         return sig.members
 
     async def join_sig(self, id: int, current_user: User) -> None:

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -14,7 +14,7 @@ from src.amqp import mq_client
 from src.core import get_settings, logger
 from src.db import get_user_role_level
 from src.dependencies import SCSCGlobalStatusDep
-from src.model import Enrollment, OldboyApplicant, StandbyReqTbl, User
+from src.model import Enrollment, OldboyApplicant, StandbyReqTbl, User, UserSummary
 from src.repositories import (
     EnrollmentRepositoryDep,
     OldboyApplicantRepositoryDep,
@@ -22,7 +22,7 @@ from src.repositories import (
     UserRepositoryDep,
     UserRoleRepositoryDep,
 )
-from src.schemas import PublicUserResponse, UserResponse, UserSummaryResponse
+from src.schemas import PublicUserResponse, UserResponse
 from src.util import (
     DepositDTO,
     generate_user_hash,
@@ -225,28 +225,12 @@ class UserService:
         users = self.user_repository.get_by_filters(filters)
         return UserResponse.model_validate_list(users)
 
-    def get_user_summaries(self, current_user: User) -> Sequence[UserSummaryResponse]:
+    def get_user_summaries(self, current_user: User) -> Sequence[UserSummary]:
         if current_user.role < get_user_role_level("executive"):
             raise HTTPException(
                 403, detail="permission denied: executive role required"
             )
-
-        users = self.user_repository.list_all()
-
-        summaries: list[UserSummaryResponse] = []
-        for user in users:
-            summaries.append(
-                UserSummaryResponse(
-                    id=user.id,
-                    name=user.name,
-                    major_id=user.major_id,
-                    role=user.role,
-                    is_active=user.is_active,
-                    is_banned=user.is_banned,
-                )
-            )
-
-        return summaries
+        return self.user_repository.get_all_summary()
 
     def get_public_executives(self) -> Sequence[PublicUserResponse]:
         return PublicUserResponse.model_validate_list(


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?

resolve #262 

---

### 이 PR이 어떤 기능을 추가했나요?

- UserSummary 모델을 만들고, 일반 사용자가 조회하는 경우(시그장, 시그원 등) 및 임원진이 사용자를 조회하는 경우에 활용함
- SIG 모델이 `owner_user`, `members`, `tags`를 포함하게 함
- PIG 모델이 `owner_user`, `members`, `websites`를 포함하게 함

---

### 주의해야 할 점이나 유의사항이 있나요?

- api docs의 예시 응답이 변경이 불편하고 중복이 많아서 schema 파일을 참고하도록 하고 응답 타입만 명시하도록 변경함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SIG and PIG responses now include nested owner details, member lists, tags (SIG) and websites (PIG); user summaries now include major info.
  * Endpoints now return validated, typed response models for list and detail requests.

* **Documentation**
  * API docs updated to reference schema types instead of inline JSON examples and to clarify status codes and response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->