### PR TITLE
:sparkles: 시그 웹사이트 구현

### DIFF
--- a/docs/api/sigpig.md
+++ b/docs/api/sigpig.md
@@ -141,6 +141,8 @@ END;
 }
 ```
 
+websites가 포함된다면, 기존의 websites는 모두 삭제되고 새로운 websites로 대체된다.
+
 * **Response**: `SigResponse`
 * **Status Codes**:
 

--- a/docs/api/sigpig.md
+++ b/docs/api/sigpig.md
@@ -71,6 +71,19 @@ CREATE TABLE pig_member (
 );
 ```
 
+## SIG/PIG Website
+```sql
+CREATE TABLE public.sig_website (
+    id BIGSERIAL PRIMARY KEY,
+    sig_id bigint NOT NULL REFERENCES public.sig(id) ON DELETE CASCADE,
+    label text NOT NULL,
+    url text NOT NULL,
+    sort_order bigint NOT NULL DEFAULT '0'::bigint,
+    created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
 ## SQL 관련
 ```sql
 CREATE INDEX idx_sig_owner ON sig(owner);
@@ -124,6 +137,7 @@ END;
   "description": "인공지능을 연구하는 소모임입니다.",
   "content": "## 안녕하세요",
   "is_rolling_admission": false,
+  "websites": []
 }
 ```
 
@@ -188,6 +202,7 @@ END;
   "content": "### 안녕하세요",
   "should_extend": true,
   "is_rolling_admission": true,
+  "websites": []
 }
 ```
 
@@ -285,6 +300,7 @@ END;
   "status": "recruiting",
   "should_extend": true,
   "is_rolling_admission": true,
+  "websites": []
 }
 ```
 
@@ -610,7 +626,6 @@ END;
 
 * 시그와 구조가 다른 피그만의 API 예외 사항은 아래와 같다.
 * 피그는 `is_rolling_admission` 이 Boolean 이 아니라 String 타입이며 `always`, `never`, `during_recruiting`의 세 가지 경우가 존재한다.
-* 피그는 웹사이트(string)을 여러 개 가질 수 있다. 
 * 응답 형식은 [/src/schemas/pig.py](/src/schemas/pig.py) 참고하십시오
 
 ---

--- a/script/migrations/V6__create_sig_website.sql
+++ b/script/migrations/V6__create_sig_website.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.sig_website (
+    id BIGSERIAL PRIMARY KEY,
+    sig_id bigint NOT NULL REFERENCES public.sig(id) ON DELETE CASCADE,
+    label text NOT NULL,
+    url text NOT NULL,
+    sort_order bigint NOT NULL DEFAULT '0'::bigint,
+    created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -8,7 +8,7 @@ from .key_value import KeyValue
 from .major import Major
 from .pig import PIG, PIGMember, PIGWebsite
 from .scsc_global_status import SCSCGlobalStatus, SCSCStatus
-from .sig import SIG, SIGMember, SIGTag, Tag
+from .sig import SIG, SIGMember, SIGTag, SIGWebsite, Tag
 from .user import (
     Enrollment,
     OldboyApplicant,

--- a/src/model/sig.py
+++ b/src/model/sig.py
@@ -79,6 +79,9 @@ class SIG(Base):
     members: Mapped[list[SIGMember]] = relationship(
         "SIGMember", lazy="selectin", init=False, viewonly=True
     )
+    websites: Mapped[list[SIGWebsite]] = relationship(
+        "SIGWebsite", lazy="selectin", init=False, viewonly=True
+    )
     tags: Mapped[list[Tag]] = relationship(
         "Tag", secondary="sig_tag", lazy="selectin", init=False, viewonly=True
     )
@@ -102,6 +105,27 @@ class SIGMember(Base):
 
     user: Mapped[UserSummary] = relationship(
         "UserSummary", lazy="selectin", init=False, viewonly=True
+    )
+
+
+class SIGWebsite(Base):
+    __tablename__ = "sig_website"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, init=False
+    )
+    sig_id: Mapped[int] = mapped_column(Integer, ForeignKey("sig.id"), nullable=False)
+    label: Mapped[str] = mapped_column(String, nullable=False)
+    url: Mapped[str] = mapped_column(String, nullable=False)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        default_factory=utcnow,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        default_factory=utcnow,
+        onupdate=utcnow,
     )
 
 

--- a/src/repositories/__init__.py
+++ b/src/repositories/__init__.py
@@ -12,6 +12,7 @@ from .sig import (
     SigMemberRepositoryDep,
     SigRepositoryDep,
     SigTagRepositoryDep,
+    SigWebsiteRepositoryDep,
     TagRepository,
     TagRepositoryDep,
 )

--- a/src/repositories/sig.py
+++ b/src/repositories/sig.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Optional, Sequence
 from fastapi import Depends
 from sqlalchemy import delete, func, select
 
-from src.model import SIG, SCSCStatus, SIGMember, SIGTag, Tag
+from src.model import SIG, SCSCStatus, SIGMember, SIGTag, SIGWebsite, Tag
 
 from .crud_repository import CRUDRepository
 
@@ -60,6 +60,30 @@ class SigMemberRepository(CRUDRepository[SIGMember, int]):
         return self.session.scalars(stmt).all()
 
 
+class SigWebsiteRepository(CRUDRepository[SIGWebsite, int]):
+    @property
+    def model(self) -> type[SIGWebsite]:
+        return SIGWebsite
+
+    def get_by_sig_id(self, sig_id: int) -> Sequence[SIGWebsite]:
+        stmt = (
+            select(SIGWebsite)
+            .where(SIGWebsite.sig_id == sig_id)
+            .order_by(SIGWebsite.sort_order, SIGWebsite.id)
+        )
+        return self.session.scalars(stmt).all()
+
+    def replace_for_sig(self, sig_id: int, websites: Sequence[SIGWebsite]) -> None:
+        with self.transaction:
+            self.session.execute(delete(SIGWebsite).where(SIGWebsite.sig_id == sig_id))
+            for website in websites:
+                self.session.add(website)
+
+    def delete_by_sig_id(self, sig_id: int) -> None:
+        with self.transaction:
+            self.session.execute(delete(SIGWebsite).where(SIGWebsite.sig_id == sig_id))
+
+
 class SigTagRepository(CRUDRepository[SIGTag, int]):
     @property
     def model(self) -> type[SIGTag]:
@@ -105,5 +129,6 @@ class TagRepository(CRUDRepository[Tag, int]):
 
 SigRepositoryDep = Annotated[SigRepository, Depends()]
 SigMemberRepositoryDep = Annotated[SigMemberRepository, Depends()]
+SigWebsiteRepositoryDep = Annotated[SigWebsiteRepository, Depends()]
 SigTagRepositoryDep = Annotated[SigTagRepository, Depends()]
 TagRepositoryDep = Annotated[TagRepository, Depends()]

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -6,7 +6,13 @@ from .key_value import KvResponse
 from .major import MajorResponse
 from .pig import PigMemberResponse, PigResponse, PigWebsiteResponse
 from .scsc_global_status import SCSCGlobalStatusResponse
-from .sig import SigMemberResponse, SigResponse, SigTagResponse, TagResponse
+from .sig import (
+    SigMemberResponse,
+    SigResponse,
+    SigTagResponse,
+    SigWebsiteResponse,
+    TagResponse,
+)
 from .user import (
     OldboyApplicantResponse,
     PublicUserResponse,

--- a/src/schemas/sig.py
+++ b/src/schemas/sig.py
@@ -21,6 +21,16 @@ class SigMemberResponse(BaseResponse):
     user: UserSummaryResponse
 
 
+class SigWebsiteResponse(BaseResponse):
+    id: int
+    sig_id: int
+    label: str
+    url: str
+    sort_order: int
+    created_at: datetime
+    updated_at: datetime
+
+
 class SigResponse(BaseResponse):
     id: int
     title: str
@@ -38,6 +48,7 @@ class SigResponse(BaseResponse):
     updated_at: datetime
     owner_user: UserSummaryResponse
     members: list[SigMemberResponse]
+    websites: list[SigWebsiteResponse]
     tags: list[TagResponse]
 
 

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -465,7 +465,7 @@ class PigService:
             label = website.label.strip()
             url = website.url.strip()
             if not url:
-                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
+                raise HTTPException(400, detail="URL이 비어 있습니다")
             if not label:
                 label = url
             sort_order = website.sort_order if website.sort_order is not None else idx

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -464,10 +464,6 @@ class PigService:
         for idx, website in enumerate(websites):
             label = (website.label or "").strip()
             url = (website.url or "").strip()
-            if not url:
-                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
-            if not label:
-                label = url
             sort_order = website.sort_order if website.sort_order is not None else idx
             prepared.append(
                 PIGWebsite(

--- a/src/services/pig.py
+++ b/src/services/pig.py
@@ -462,8 +462,12 @@ class PigService:
 
         prepared: list[PIGWebsite] = []
         for idx, website in enumerate(websites):
-            label = (website.label or "").strip()
-            url = (website.url or "").strip()
+            label = website.label.strip()
+            url = website.url.strip()
+            if not url:
+                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
+            if not label:
+                label = url
             sort_order = website.sort_order if website.sort_order is not None else idx
             prepared.append(
                 PIGWebsite(

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -477,10 +477,6 @@ class SigService:
         for idx, website in enumerate(websites):
             label = (website.label or "").strip()
             url = (website.url or "").strip()
-            if not url:
-                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
-            if not label:
-                label = url
             sort_order = website.sort_order if website.sort_order is not None else idx
             prepared.append(
                 SIGWebsite(

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -475,8 +475,12 @@ class SigService:
 
         prepared: list[SIGWebsite] = []
         for idx, website in enumerate(websites):
-            label = (website.label or "").strip()
-            url = (website.url or "").strip()
+            label = website.label.strip()
+            url = website.url.strip()
+            if not url:
+                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
+            if not label:
+                label = url
             sort_order = website.sort_order if website.sort_order is not None else idx
             prepared.append(
                 SIGWebsite(

--- a/src/services/sig.py
+++ b/src/services/sig.py
@@ -7,11 +7,21 @@ from sqlalchemy.exc import IntegrityError
 from src.amqp import mq_client
 from src.core import logger
 from src.db import get_user_role_level
-from src.model import SIG, SCSCGlobalStatus, SCSCStatus, SIGMember, SIGTag, Tag, User
+from src.model import (
+    SIG,
+    SCSCGlobalStatus,
+    SCSCStatus,
+    SIGMember,
+    SIGTag,
+    SIGWebsite,
+    Tag,
+    User,
+)
 from src.repositories import (
     SigMemberRepositoryDep,
     SigRepositoryDep,
     SigTagRepositoryDep,
+    SigWebsiteRepositoryDep,
     TagRepositoryDep,
     UserRepositoryDep,
 )
@@ -21,11 +31,18 @@ from .article import ArticleServiceDep, BodyCreateArticle
 from .scsc import ctrl_status_available
 
 
+class BodySigWebsite(BaseModel):
+    label: str
+    url: str
+    sort_order: Optional[int] = None
+
+
 class BodyCreateSIG(BaseModel):
     title: str
     description: str
     content: str
     is_rolling_admission: bool = False
+    websites: Optional[list[BodySigWebsite]] = None
 
 
 class BodyUpdateSIG(BaseModel):
@@ -35,6 +52,7 @@ class BodyUpdateSIG(BaseModel):
     status: Optional[SCSCStatus] = None
     should_extend: Optional[bool] = None
     is_rolling_admission: Optional[bool] = None
+    websites: Optional[list[BodySigWebsite]] = None
 
 
 class BodyHandoverSIG(BaseModel):
@@ -55,6 +73,7 @@ class SigService:
         article_service: ArticleServiceDep,
         sig_repository: SigRepositoryDep,
         sig_member_repository: SigMemberRepositoryDep,
+        sig_website_repository: SigWebsiteRepositoryDep,
         sig_tag_repository: SigTagRepositoryDep,
         tag_repository: TagRepositoryDep,
         user_repository: UserRepositoryDep,
@@ -62,6 +81,7 @@ class SigService:
         self.article_service = article_service
         self.sig_repository = sig_repository
         self.sig_member_repository = sig_member_repository
+        self.sig_website_repository = sig_website_repository
         self.sig_tag_repository = sig_tag_repository
         self.tag_repository = tag_repository
         self.user_repository = user_repository
@@ -107,6 +127,8 @@ class SigService:
 
         if sig.id is None:
             raise HTTPException(503, detail="sig primary key does not exist")
+
+        self._replace_websites(sig.id, body.websites)
 
         sig_member = SIGMember(ig_id=sig.id, user_id=current_user.id)
         try:
@@ -204,6 +226,9 @@ class SigService:
             self.sig_repository.update(sig)
         except IntegrityError:
             raise HTTPException(409, detail="기존 시그/피그와 중복된 항목이 있습니다")
+
+        if body.websites is not None:
+            self._replace_websites(id, body.websites)
 
         bot_body = {}
         bot_body["sig_name"] = old_title
@@ -429,6 +454,43 @@ class SigService:
         logger.info(
             f"info_type=sig_leave ; {sig.id=} ; {sig.title=} ; {executor.id=} ; left_user_id={body.user_id} ; {sig.year=} ; {sig.semester=}"
         )
+
+    def _replace_websites(
+        self, sig_id: int, websites: Optional[Sequence[BodySigWebsite]]
+    ) -> None:
+        if websites is None:
+            return
+        website_models = self._prepare_website_models(sig_id, websites)
+        self.sig_website_repository.replace_for_sig(sig_id, website_models)
+
+    def _prepare_website_models(
+        self, sig_id: int, websites: Sequence[BodySigWebsite]
+    ) -> list[SIGWebsite]:
+        if not websites:
+            return []
+        if len(websites) > 10:
+            raise HTTPException(
+                400, detail="웹사이트는 최대 10개까지 등록할 수 있습니다"
+            )
+
+        prepared: list[SIGWebsite] = []
+        for idx, website in enumerate(websites):
+            label = (website.label or "").strip()
+            url = (website.url or "").strip()
+            if not url:
+                raise HTTPException(400, detail="웹사이트 주소는 필수입니다")
+            if not label:
+                label = url
+            sort_order = website.sort_order if website.sort_order is not None else idx
+            prepared.append(
+                SIGWebsite(
+                    sig_id=sig_id,
+                    label=label,
+                    url=url,
+                    sort_order=sort_order,
+                )
+            )
+        return prepared
 
     def add_sig_tag(self, sig_id: int, tag_id: int, executor: User) -> SIGTag:
         sig = self.sig_repository.get_by_id(sig_id)


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?

resolve #276 

---

### 이 PR이 어떤 기능을 추가했나요?

- 시그에 피그와 동일한 링크 연결 기능 추가

---

### 주의해야 할 점이나 유의사항이 있나요?

<!-- 없으면 "None"을 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SIGs can have multiple websites (up to 10). Create/update endpoints accept website lists; responses include website details (label, URL, sort order). Providing a websites list replaces existing websites for that SIG.

* **Documentation**
  * API docs updated with website examples for Create/Update SIG and a note about replacement behavior; removed the prior SIG/PIG multiple-websites exception.

* **Validation**
  * Improved website input validation and clearer error messaging for invalid/empty URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->