### PR TITLE
♻️ 전역 Lifecycle에서 inactive 삭제

### DIFF
--- a/src/services/scsc.py
+++ b/src/services/scsc.py
@@ -175,6 +175,26 @@ class SCSCService:
                 detail="failed to back up database before status change",
             ) from exc
 
+        # start of recruiting
+        if new_status == SCSCStatus.RECRUITING:
+            (year, semester) = (scsc_global_status.year, scsc_global_status.semester)
+            if semester % 2 == 0:
+                (year, semester) = get_next_year_semester(year, semester)
+            if mq_client:
+                await mq_client.send_discord_bot_request_no_reply(
+                    action_code=3002,
+                    body={
+                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} SIG Archive"
+                    },
+                )
+            if mq_client:
+                await mq_client.send_discord_bot_request_no_reply(
+                    action_code=3004,
+                    body={
+                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} PIG Archive"
+                    },
+                )
+
         # start of active (recruiting -> active)
         if new_status == SCSCStatus.ACTIVE:
             self.session.execute(

--- a/src/services/scsc.py
+++ b/src/services/scsc.py
@@ -26,10 +26,8 @@ from .key_value import KvServiceDep
 from .user import OldboyServiceDep, UserServiceDep
 
 _valid_scsc_global_status_update = (
-    (SCSCStatus.INACTIVE, SCSCStatus.RECRUITING),
     (SCSCStatus.RECRUITING, SCSCStatus.ACTIVE),
     (SCSCStatus.ACTIVE, SCSCStatus.RECRUITING),
-    (SCSCStatus.ACTIVE, SCSCStatus.INACTIVE),
 )
 
 
@@ -80,7 +78,7 @@ class SCSCService:
         return self.scsc_global_status
 
     def get_all_statuses(self) -> dict[str, list[str]]:
-        return {"statuses": ["recruiting", "active", "inactive"]}
+        return {"statuses": ["recruiting", "active"]}
 
     async def _process_igs_change_semester(
         self, model: Type[SIG | PIG], scsc_global_status: SCSCGlobalStatus
@@ -177,24 +175,7 @@ class SCSCService:
                 detail="failed to back up database before status change",
             ) from exc
 
-        # start of recruiting
-        if new_status == SCSCStatus.RECRUITING:
-            if mq_client:
-                await mq_client.send_discord_bot_request_no_reply(
-                    action_code=3002,
-                    body={
-                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} SIG Archive"
-                    },
-                )
-            if mq_client:
-                await mq_client.send_discord_bot_request_no_reply(
-                    action_code=3004,
-                    body={
-                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} PIG Archive"
-                    },
-                )
-
-        # start of active
+        # start of active (recruiting -> active)
         if new_status == SCSCStatus.ACTIVE:
             self.session.execute(
                 update(SIG)
@@ -210,7 +191,7 @@ class SCSCService:
                 .execution_options(synchronize_session=False)
             )
 
-        # end of active
+        # end of active (active -> recruiting, semester changes)
         if scsc_global_status.status == SCSCStatus.ACTIVE:
             if mq_client:
                 await mq_client.send_discord_bot_request_no_reply(
@@ -270,8 +251,8 @@ class SCSCService:
             )
             self.standby_repository.delete_all()
 
-        # start of inactive (regular semester starts)
-        if new_status == SCSCStatus.INACTIVE:
+        # start of regular semester
+        if scsc_global_status.status == SCSCStatus.ACTIVE and scsc_global_status.semester % 2 == 0:
             unprocessed_applicants = self.oldboy_repository.get_unprocessed()
             for applicant in unprocessed_applicants:
                 try:

--- a/src/services/scsc.py
+++ b/src/services/scsc.py
@@ -175,7 +175,6 @@ class SCSCService:
                 detail="failed to back up database before status change",
             ) from exc
 
-
         # start of active (recruiting -> active)
         if new_status == SCSCStatus.ACTIVE:
             self.session.execute(
@@ -229,7 +228,7 @@ class SCSCService:
                             "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} PIG Archive"
                         },
                     )
-                
+
                 next_year, next_semester = get_next_year_semester(
                     scsc_global_status.year, scsc_global_status.semester
                 )

--- a/src/services/scsc.py
+++ b/src/services/scsc.py
@@ -175,25 +175,6 @@ class SCSCService:
                 detail="failed to back up database before status change",
             ) from exc
 
-        # start of recruiting
-        if new_status == SCSCStatus.RECRUITING:
-            (year, semester) = (scsc_global_status.year, scsc_global_status.semester)
-            if semester % 2 == 0:
-                (year, semester) = get_next_year_semester(year, semester)
-            if mq_client:
-                await mq_client.send_discord_bot_request_no_reply(
-                    action_code=3002,
-                    body={
-                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} SIG Archive"
-                    },
-                )
-            if mq_client:
-                await mq_client.send_discord_bot_request_no_reply(
-                    action_code=3004,
-                    body={
-                        "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} PIG Archive"
-                    },
-                )
 
         # start of active (recruiting -> active)
         if new_status == SCSCStatus.ACTIVE:
@@ -248,6 +229,23 @@ class SCSCService:
                             "category_name": f"{scsc_global_status.year}-{map_semester_name.get(scsc_global_status.semester)} PIG Archive"
                         },
                     )
+                
+                next_year, next_semester = get_next_year_semester(
+                    scsc_global_status.year, scsc_global_status.semester
+                )
+
+                await mq_client.send_discord_bot_request_no_reply(
+                    action_code=3002,
+                    body={
+                        "category_name": f"{next_year}-{map_semester_name.get(next_semester)} SIG Archive"
+                    },
+                )
+                await mq_client.send_discord_bot_request_no_reply(
+                    action_code=3004,
+                    body={
+                        "category_name": f"{next_year}-{map_semester_name.get(next_semester)} PIG Archive"
+                    },
+                )
 
             await self._process_igs_change_semester(SIG, scsc_global_status)
             await self._process_igs_change_semester(PIG, scsc_global_status)

--- a/src/services/scsc.py
+++ b/src/services/scsc.py
@@ -252,7 +252,10 @@ class SCSCService:
             self.standby_repository.delete_all()
 
         # start of regular semester
-        if scsc_global_status.status == SCSCStatus.ACTIVE and scsc_global_status.semester % 2 == 0:
+        if (
+            scsc_global_status.status == SCSCStatus.ACTIVE
+            and scsc_global_status.semester % 2 == 0
+        ):
             unprocessed_applicants = self.oldboy_repository.get_unprocessed()
             for applicant in unprocessed_applicants:
                 try:


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?

<!-- fixed #n의 형식으로 작성해 주세요 -->

---

fixed #250 

### 이 PR이 어떤 기능을 추가했나요?

<!-- 구현한 기능 또는 개선 사항에 대해 설명해 주세요 -->

---

- _valid_scsc_global_status_update에서 SCSCStatus.INACTIVE를 포함하는 항목 제거
- get_all_statuses 함수의 반환값에서 "inactive" 제거
- update_global_status 함수에서 상황별 실행 사항을 다음과 같이 변경

#### active 시작 시 (정규, 계절학기 recruiting -> active)
- 시그, 피그의 상태를 recruiting에서 active로 변경

#### active 종료 시 (학기 변경; 정규학기 active -> 계절학기 recruiting, 계절학기 active -> 정규학기 recruiting)
- 요청 처리 전, 현재 등록 정책을 확인하여 부여할 마지막 학기가 현재 또는 과거의 학기라면 전역 상태 변경 요청을 거부
- 디스코드 봇 학기 변경, 아카이브 카테고리 갱신
- 모든 활성 시그, 피그에 대해:
  - should_extend이면 상태를 recruiting으로, 학기를 다음 학기로 변경
  - 아니면 상태를 inactive로 변경, 디스코드 채널을 아카이브 카테고리로 이동
- 모든 제명되지 않고 권한이 정회원 이하인 사용자에 대해:
  - 다음 학기 등록 기록이 있으면 상태를 활성으로, 그렇지 않으면 상태를 비활성으로 변경
- 입금 확인 대기 목록 초기화

#### 정규학기로 변경 시(계절학기 active -> 정규학기 recruiting)
- 졸업생 신청 처리
- inactive이고 권한이 정회원 이하인 사용자의 권한을 휴회원으로 변경


### 주의해야 할 점이나 유의사항이 있나요?

<!-- 없으면 "None"을 작성해 주세요 -->
제가 이해하기로는 기존 코드에서 (정규학기 inactive) -> (정규학기 recruiting)으로 넘어가는 과정에서 (2026-2학기라고 한다면) 디스코드에 2026-2 SIG/PIG Archive 카테고리가 생성되는 것으로 보입니다. 이에 따라 (계절학기 active) -> (정규학기 inactive) -> (정규학기 recruiting) 과정을 통합하면 2026-S SIG/PIG Archive와 2026-2 SIG/PIG Archive가 동시에 생성됩니다. 이런 경우 (정규학기 active) -> (계절학기 recruiting)과 통일되지 않아보여서, 일단은 2026-S SIG/PIG Archive 카테고리만 갱신하는 것이 원래 의도라 생각하고 '# start of recruiting' 부분을 삭제하는 방식으로 구현했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted allowed global status transitions to only "recruiting" and "active".
  * Removed "inactive" from public status listing and adjusted automated workflows accordingly.

* **Refactor**
  * Updated semester-transition logic and applicant processing triggers to rely on previous-state and semester parity.
  * Simplified recruiting→active flow and clarified related control flow descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->