### PR TITLE
✨프런트엔드 html 다운로드 기능 관련 수정사항

### DIFF
--- a/src/routes/w.py
+++ b/src/routes/w.py
@@ -51,3 +51,12 @@ async def delete_w_by_name(
     w_service: WServiceDep,
 ) -> None:
     await w_service.delete_w_by_name(name, current_user)
+
+
+@w_router.get("/executive/w/{name}/download")
+async def download_w_by_name(
+    name: str,
+    current_user: UserDep,
+    w_service: WServiceDep,
+):
+    return w_service.download_w_by_name(name, current_user)

--- a/src/services/w.py
+++ b/src/services/w.py
@@ -1,5 +1,5 @@
 import re
-from os import path
+from os import name, path
 from typing import Annotated, Sequence
 
 import aiofiles
@@ -98,6 +98,16 @@ class WService:
             f"info_type=w_html_updated ; {name=} ; file_size={len(content)} ; executer_id={current_user.id}"
         )
         return w_meta
+
+    def download_w_by_name(self, name: str, current_user: User) -> FileResponse:
+        w_meta = self.w_repository.get_by_id(name)
+        if not w_meta:
+            raise HTTPException(404, detail="file not found")
+        return FileResponse(
+            path.join(get_settings().w_html_dir, f"{name}.html"),
+            media_type="text/html",
+            filename=f"{name}.html",
+        )
 
     async def delete_w_by_name(self, name: str, current_user: User) -> None:
         w_meta = self.w_repository.get_by_id(name)

--- a/src/services/w.py
+++ b/src/services/w.py
@@ -103,8 +103,11 @@ class WService:
         w_meta = self.w_repository.get_by_id(name)
         if not w_meta:
             raise HTTPException(404, detail="file not found")
+        file_path = path.join(get_settings().w_html_dir, f"{name}.html")
+        if not path.isfile(file_path):
+            raise HTTPException(404, detail="file not found")
         return FileResponse(
-            path.join(get_settings().w_html_dir, f"{name}.html"),
+            file_path,
             media_type="text/html",
             filename=f"{name}.html",
         )


### PR DESCRIPTION
### What feature does this PR add?
✨ 임원 W 페이지 다운로드 API 엔드포인트 추가

`GET /executive/w/{name}/download` 엔드포인트와 이에 대응하는 `WService.download_w_by_name` 메서드를 추가했습니다. 해당 엔드포인트는 기존 `get_w_by_name`과 동일하게 파일을 반환하되, `Content-Disposition: attachment` 헤더를 포함하여 브라우저가 파일을 렌더링하지 않고 다운로드하도록 합니다.

---
### Are there any caveats or things to watch out for?
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New download endpoint added allowing authenticated users to retrieve W files by specific file name with proper file serving and authentication controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->