### PR TITLE
⚡bugfix for FE issue #637

### DIFF
--- a/src/services/comment.py
+++ b/src/services/comment.py
@@ -42,8 +42,6 @@ class CommentService:
             raise HTTPException(
                 status_code=404, detail=f"Article {body.article_id} does not exist"
             )
-        if article.is_deleted:
-            raise HTTPException(status_code=410, detail="Article has been deleted")
         board = self.board_repository.get_by_id(article.board_id)
         if not board:
             raise HTTPException(503, detail="board does not exist")


### PR DESCRIPTION
<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?

FE issue 367(https://github.com/scsc-init/homepage_init_frontend/pull/657)

---

### 이 PR이 어떤 기능을 추가했나요?
댓글 작성 시 발생하던 댓글 생성 실패(`Failed to fetch`) 버그 수정

- `src/services/comment.py`의 `create_comment`에서 `article.is_deleted`를 참조하던
  코드(2줄)를 제거
- `Article` 모델은 백엔드 PR #313(article soft delete를 hard delete로 변경) 이후 `is_deleted` 필드가 없어졌는데,
  `create_comment`만 이 필드를 계속 참조하고 있었어서, 그 결과 댓글 작성 시`AttributeError`가 발생해 처리되지 않은 500 오류가 났음
- 게시글은 이제 hard delete되므로, 삭제된 게시글은 조회되지 않아 바로 위의 `if not article` (404) 검사로 이미 처리됨



### 주의해야 할 점이나 유의사항이 있나요?
- 댓글 조회(GET)는 `article.is_deleted`를 참조하지 않아 영향이 없었고, 그래서 댓글 작성만 실패함
- 다른 생성 기능(게시글/SIG/PIG)은 이 코드를 거치지 않아 영향 X