### PR TITLE
⚡✨KV 업데이트 입력 검증 및 예외 핸들러 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from src.amqp import mq_client
 
 # Middleware
-from src.core import get_settings, logger, register_exception_handlers
+from src.core import get_settings, logger, unhandled_exception_handler
 
 # Dependencies
 from src.dependencies import check_user_status, user_auth
@@ -80,6 +80,8 @@ else:
 # Request flow (outer -> inner): HTTPLogger -> AssertPermission
 app.add_middleware(AssertPermissionMiddleware)
 app.add_middleware(HTTPLoggerMiddleware)
+
+app.add_exception_handler(Exception, unhandled_exception_handler)
 
 app.include_router(root_router)
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from src.amqp import mq_client
 
 # Middleware
-from src.core import get_settings, logger
+from src.core import get_settings, logger, register_exception_handlers
 
 # Dependencies
 from src.dependencies import check_user_status, user_auth

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,2 +1,3 @@
 from .config import get_settings
+from .exception_handlers import register_exception_handlers
 from .logger import logger

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,3 +1,3 @@
 from .config import get_settings
-from .exception_handlers import register_exception_handlers
+from .exception_handlers import unhandled_exception_handler
 from .logger import logger

--- a/src/core/exception_handlers.py
+++ b/src/core/exception_handlers.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import FastAPI, Request
+from fastapi import Request
 from fastapi.responses import JSONResponse
 
 from .config import get_settings
@@ -32,7 +32,3 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         content={"detail": "Internal Server Error"},
         headers=cors_headers_for_origin(request.headers.get("origin")),
     )
-
-
-def register_exception_handlers(app: FastAPI) -> None:
-    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/src/core/exception_handlers.py
+++ b/src/core/exception_handlers.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from .config import get_settings
+from .logger import logger
+
+
+def cors_headers_for_origin(origin: Optional[str]) -> dict[str, str]:
+    if not origin:
+        return {}
+    settings = get_settings()
+    is_allowed = settings.cors_all_accept or origin in settings.cors_whitelist_origins
+    if not is_allowed:
+        return {}
+    return {
+        "Access-Control-Allow-Origin": origin,
+        "Access-Control-Allow-Credentials": "true",
+        "Vary": "Origin",
+    }
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception(
+        "info_type=unhandled_exception ; method=%s ; path=%s",
+        request.method,
+        request.url.path,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+        headers=cors_headers_for_origin(request.headers.get("origin")),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/src/model/key_value.py
+++ b/src/model/key_value.py
@@ -12,7 +12,7 @@ class KeyValue(Base):
     __tablename__ = "key_value"
 
     key: Mapped[str] = mapped_column(String, primary_key=True)
-    value: Mapped[str] = mapped_column(String, default=None, nullable=False)
+    value: Mapped[str] = mapped_column(String, nullable=False)
     writing_permission_level: Mapped[int] = mapped_column(
         Integer, ForeignKey("user_role.level"), default=500
     )

--- a/src/model/key_value.py
+++ b/src/model/key_value.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Optional
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
@@ -13,7 +12,7 @@ class KeyValue(Base):
     __tablename__ = "key_value"
 
     key: Mapped[str] = mapped_column(String, primary_key=True)
-    value: Mapped[Optional[str]] = mapped_column(String, default=None, nullable=True)
+    value: Mapped[str] = mapped_column(String, default=None, nullable=False)
     writing_permission_level: Mapped[int] = mapped_column(
         Integer, ForeignKey("user_role.level"), default=500
     )

--- a/src/services/key_value.py
+++ b/src/services/key_value.py
@@ -2,6 +2,7 @@ from typing import Annotated, Optional, Sequence
 
 from fastapi import Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 
 from src.core import logger
 from src.model import KeyValue, User
@@ -9,7 +10,7 @@ from src.repositories import KeyValueRepositoryDep
 
 
 class KvUpdateBody(BaseModel):
-    value: Optional[str]
+    value: str
 
 
 class KvService:
@@ -37,7 +38,10 @@ class KvService:
             raise HTTPException(status_code=403, detail="insufficient permission")
 
         kv_entry.value = body.value
-        updated_entry = self.kv_repository.update(kv_entry)
+        try:
+            updated_entry = self.kv_repository.update(kv_entry)
+        except IntegrityError:
+            raise HTTPException(status_code=400, detail="invalid kv value")
 
         logger.info(
             "info_type=kv_updated ; key=%s ; value=%s ; updater_id=%s",


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?
fixed #339 
---

### 이 PR이 어떤 기능을 추가했나요?
KV 업데이트에 잘못된 입력(value=null)을 보내면 500이 발생하고, 그 500 응답에 CORS 헤더가 없어 프론트에서 원인이 "CORS 에러"로 가려지는 문제를 해결했습니다.

- `services/key_value.py`: DB 쓰기를 `try/except IntegrityError → HTTPException(400)`으로 감쌈
- `model/key_value.py`: `value`를 `nullable=False`로 수정
<img width="1470" height="796" alt="Screenshot 2026-07-09 at 10 37 10 PM" src="https://github.com/user-attachments/assets/94b89104-dcf9-4458-af42-630932377d51" />


- `src/core/exception_handlers.py` (신규): 어디서든 처리되지 않은 예외가 발생하면 `500 {"detail": "Internal Server Error"}`를 반환하되, 요청 Origin 기준으로 CORS 헤더를 다시 부착. Origin 허용 여부는 기존 CORS 미들웨어와 동일한 설정(`cors_all_accept` / `cors_whitelist_origins`)을 사용.
---

### 주의해야 할 점이나 유의사항이 있나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Key-value updates now require a value, preventing attempts to save missing/empty entries.
  * If an entered value violates storage constraints, the API returns a clearer 400 “invalid kv value” response.
  * Existing not-found and permission error behavior for key-value updates remains unchanged.
* **Improvements**
  * Unhandled server errors are now handled more consistently, returning a standardized JSON 500 response and applying appropriate CORS headers when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->