### PR TITLE
✨user에 kakao_name 컬럼 추가 및 회원가입 저장(FE이슈 709)

### DIFF
--- a/script/migrations/V16__add_kakao_name_to_user.sql
+++ b/script/migrations/V16__add_kakao_name_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public."user"
+    ADD COLUMN kakao_name TEXT;

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -47,6 +47,10 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
+    kakao_name: Mapped[Optional[str]] = mapped_column(
+        String, default=None, nullable=True
+    )
+
     discord_id: Mapped[Optional[int]] = mapped_column(
         default=None, nullable=True, unique=True
     )

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -28,6 +28,7 @@ class UserResponse(BaseResponse):
 class UserSummaryResponse(BaseResponse):
     id: str
     name: str
+    kakao_name: Optional[str] = None
     email: str
     major_id: int
     role: int

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -9,6 +9,7 @@ class UserResponse(BaseResponse):
     id: str
     email: str
     name: str
+    kakao_name: Optional[str] = None
     phone: str
     student_id: str
     role: int

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -82,6 +82,7 @@ class BodyUpdateUser(BaseModel):
 
 class BodyUpdateMyProfile(BaseModel):
     name: Optional[str] = None
+    kakao_name: Optional[str] = None
     phone: Optional[str] = None
     student_id: Optional[str] = None
     major_id: Optional[int] = None
@@ -307,6 +308,9 @@ class UserService:
 
         if body.name:
             current_user.name = body.name
+        if body.kakao_name is not None:
+            # empty string clears the field back to NULL
+            current_user.kakao_name = body.kakao_name.strip() or None
         if body.phone:
             current_user.phone = body.phone
         if body.student_id:

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -50,6 +50,7 @@ from .key_value import KvServiceDep
 class BodyCreateUser(BaseModel):
     email: str
     name: str
+    kakao_name: Optional[str] = None
     phone: str
     student_id: str
     major_id: int
@@ -152,10 +153,12 @@ class UserService:
         if not hmac.compare_digest(body.hashToken, expected):
             raise HTTPException(401, detail="invalid hash token")
 
+        kakao_name = body.kakao_name.strip() if body.kakao_name else None
         user = User(
             id=sha256_hash(body.email.lower()),
             email=body.email,
             name=body.name,
+            kakao_name=kakao_name or None,
             phone=body.phone,
             student_id=body.student_id,
             role=get_user_role_level("newcomer"),


### PR DESCRIPTION
### 이 PR이 어떤 이슈를 고쳤나요?
fixed #709 (https://github.com/scsc-init/homepage_init_frontend/issues/709)

---

### 이 PR이 어떤 기능을 추가했나요?
- `user` 테이블에 선택 컬럼 **`kakao_name`(nullable TEXT)** 추가
- 회원가입(`/api/user/create`)에서 `kakao_name`을 받아 저장(공백 trim, 비어 있으면 `NULL`)
- `UserResponse`에 `kakao_name` 노출
- 본인 프로필 수정(/api/user/update)에서 kakao_name 수정 지원 — 빈 문자열로 보내면 null로 초기화(삭제)
- UserResponse, UserSummaryResponse에 kakao_name 추가(운영진 요약 테이블에서 조회 가능)
---

### 주의해야 할 점이나 유의사항이 있나요?

<!-- 없으면 "None"을 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kakao names to user profiles.
  * Users can provide, update, or clear their Kakao name.
  * Kakao names are automatically trimmed, and blank values are treated as empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->