### PR TITLE
외부회원 신청에 카톡이름 구분 기능 추가

### DIFF
--- a/script/migrations/V18__add_kakao_name_to_external_member_application.sql
+++ b/script/migrations/V18__add_kakao_name_to_external_member_application.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.external_member_application
+    ADD COLUMN kakao_name TEXT;

--- a/src/model/user.py
+++ b/src/model/user.py
@@ -202,6 +202,11 @@ class ExternalMemberApplication(Base):
         default=None,
         nullable=True,
     )
+    kakao_name: Mapped[Optional[str]] = mapped_column(
+        String,
+        default=None,
+        nullable=True,
+    )
     status: Mapped[str] = mapped_column(
         String,
         default="pending",

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -72,6 +72,7 @@ class BodyCreateExternalMemberApplication(BaseModel):
     phone: str
     student_id: Optional[str] = None
     reason: Optional[str] = None
+    kakao_name: Optional[str] = None
     hashToken: str
 
 
@@ -612,6 +613,7 @@ class ExternalMemberService:
     ) -> ExternalMemberApplication:
         email = body.email.strip().lower()
         name = body.name.strip()
+        kakao_name = body.kakao_name.strip() if body.kakao_name else None
 
         if not email or not name:
             raise HTTPException(422, detail="email and name are required")
@@ -638,6 +640,7 @@ class ExternalMemberService:
             existing_application.phone = body.phone
             existing_application.student_id = body.student_id
             existing_application.reason = body.reason
+            existing_application.kakao_name = kakao_name or None
             existing_application.status = "pending"
             existing_application.reviewed_by = None
 
@@ -649,6 +652,7 @@ class ExternalMemberService:
             phone=body.phone,
             student_id=body.student_id,
             reason=body.reason,
+            kakao_name=kakao_name or None,
         )
 
         try:
@@ -685,6 +689,7 @@ class ExternalMemberService:
             id=user_id,
             email=application.email,
             name=application.name,
+            kakao_name=application.kakao_name,
             phone=application.phone,
             student_id=application.student_id,
             role=get_user_role_level("external"),

--- a/tests/test_external_member_api.py
+++ b/tests/test_external_member_api.py
@@ -230,3 +230,44 @@ def test_rejected_external_member_can_reapply(
     assert data["reason"] == "내용을 수정하여 재신청"
     assert data["status"] == "pending"
     assert data["reviewed_by"] is None
+
+
+def test_external_member_kakao_name_is_stored_and_propagated_on_approval(
+    api_client,
+    build_headers,
+    create_user,
+    db_session,
+):
+    from src.model import User
+    from src.util import sha256_hash
+
+    email = "kakao-external@example.com"
+
+    create_response = api_client.post(
+        "/api/user/external/register",
+        headers=build_headers(),
+        json={
+            "email": email,
+            "name": "카톡 이름 신청자",
+            "phone": "01033334444",
+            "student_id": None,
+            "reason": "카톡 이름 테스트",
+            "kakao_name": "실제카톡이름",
+            "hashToken": generate_user_hash(email),
+        },
+    )
+    assert create_response.status_code == 201
+    assert create_response.json()["kakao_name"] == "실제카톡이름"
+
+    application_id = create_response.json()["id"]
+    _, executive_token = create_user(role_level=500)
+
+    approve_response = api_client.post(
+        f"/api/executive/user/external/{application_id}/approve",
+        headers=build_headers(executive_token),
+    )
+    assert approve_response.status_code == 200
+
+    external_user = db_session.get(User, sha256_hash(email))
+    assert external_user is not None
+    assert external_user.kakao_name == "실제카톡이름"


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->
<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?
fixed (https://github.com/scsc-init/homepage_init_frontend/issues/742)
<!-- fixed #n의 형식으로 작성해 주세요 -->

---

### 이 PR이 어떤 기능을 추가했나요?

<!-- 구현한 기능 또는 개선 사항에 대해 설명해 주세요 -->

---

### 주의해야 할 점이나 유의사항이 있나요?

<!-- 없으면 "None"을 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External member applications can now include an optional Kakao name.
  * The Kakao name is retained when applications are resubmitted and transferred to the user account upon approval.

* **Bug Fixes**
  * Improved consistency of Kakao name handling throughout the external membership application process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->