### PR TITLE
✨비로그인 요청에 시그 구성원, 시그장 정보를 응답하지 않도록 변경

### DIFF
--- a/src/routes/sig.py
+++ b/src/routes/sig.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
-from src.dependencies import SCSCGlobalStatusDep, UserDep
+from src.dependencies import NullableUserDep, SCSCGlobalStatusDep, UserDep
 from src.model import SCSCStatus
 from src.schemas import SigMemberResponse, SigResponse, SigTagResponse, TagResponse
 from src.services import (
@@ -35,12 +35,19 @@ async def create_sig(
 
 
 @sig_router.get("/sig/{id}")
-async def get_sig_by_id(id: int, sig_service: SigServiceDep) -> SigResponse:
-    return SigResponse.model_validate(sig_service.get_by_id(id))
+async def get_sig_by_id(
+    id: int,
+    current_user: NullableUserDep,
+    sig_service: SigServiceDep,
+) -> SigResponse:
+    return SigResponse.model_validate_visible(
+        sig_service.get_by_id(id), include_members=current_user is not None
+    )
 
 
 @sig_router.get("/sigs")
 async def get_all_sigs(
+    current_user: NullableUserDep,
     sig_service: SigServiceDep,
     year: Optional[int] = None,
     semester: Optional[int] = None,
@@ -53,7 +60,9 @@ async def get_all_sigs(
         status,
         tag,
     )
-    return SigResponse.model_validate_list(sigs)
+    return SigResponse.model_validate_visible_list(
+        sigs, include_members=current_user is not None
+    )
 
 
 @sig_router.post("/sig/{id}/update", status_code=204)
@@ -116,7 +125,9 @@ async def executive_handover_sig(
 
 @sig_router.get("/sig/{id}/members")
 async def get_sig_members(
-    id: int, sig_service: SigServiceDep
+    id: int,
+    current_user: NullableUserDep,
+    sig_service: SigServiceDep,
 ) -> Sequence[SigMemberResponse]:
     return SigMemberResponse.model_validate_list(sig_service.get_members(id))
 

--- a/src/schemas/sig.py
+++ b/src/schemas/sig.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Optional, Sequence
 
 from src.model import SCSCStatus
 from src.model.sig import RollingAdmission
@@ -48,10 +49,35 @@ class SigResponse(BaseResponse):
     is_rolling_admission: RollingAdmission
     created_at: datetime
     updated_at: datetime
-    owner_user: UserSummaryResponse
-    members: list[SigMemberResponse]
+    owner_user: Optional[UserSummaryResponse] = None
+    members: Optional[list[SigMemberResponse]] = None
     websites: list[SigWebsiteResponse]
     tags: list[TagResponse]
+
+    @classmethod
+    def model_validate_visible(
+        cls, sig: Any, *, include_members: bool
+    ) -> "SigResponse":
+        """구성원 정보는 로그인한 사용자에게만 응답한다.
+
+        owner_user와 members는 이름/이메일/카카오 이름 등 개인정보를 담고 있어
+        비로그인 요청에서는 None으로 응답한다. 시그 자체의 정보(제목, 설명,
+        태그, 웹사이트 등)는 그대로 공개된다.
+        """
+        response = cls.model_validate(sig)
+        if not include_members:
+            response.owner_user = None
+            response.members = None
+        return response
+
+    @classmethod
+    def model_validate_visible_list(
+        cls, sigs: Sequence[Any], *, include_members: bool
+    ) -> Sequence["SigResponse"]:
+        return [
+            cls.model_validate_visible(sig, include_members=include_members)
+            for sig in sigs
+        ]
 
 
 class SigTagResponse(BaseResponse):


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

<!--
백엔드 PR 올리기 전 확인 사항
1. 수정한 부분 정상 작동 테스트
2. 수정한 부분 관련 문서화
3. develop 브랜치 수정사항 병합
-->

### 이 PR이 어떤 이슈를 고쳤나요?
fixed #348 
<!-- fixed #n의 형식으로 작성해 주세요 -->

---

### 이 PR이 어떤 기능을 추가했나요?
### `src/schemas/sig.py`
- `SigResponse.members`, `SigResponse.owner_user`를 `Optional`로 변경 (기본값 `None`)
- `model_validate_visible(sig, *, include_members)` / `model_validate_visible_list(...)` 추가
  - `include_members=False`이면 두 필드를 `None`으로 비운 응답을 만든다

### `src/routes/sig.py`
- `GET /api/sig/{id}`, `GET /api/sigs`: `NullableUserDep`를 받아 `include_members=current_user is not None`로 분기
- `GET /api/sig/{id}/members`: `UserDep` 추가 → 비로그인 요청은 401

<!-- 구현한 기능 또는 개선 사항에 대해 설명해 주세요 -->

---

### 주의해야 할 점이나 유의사항이 있나요?
https://github.com/scsc-init/homepage_init_frontend/pull/761
<!-- 없으면 "None"을 작성해 주세요 -->
